### PR TITLE
Add rtcEnvironBstr hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@ bson/bson.sdf
 bson/bson.v11.suo
 bson/bson.v12.suo
 bson/bson.vcxproj.user
+bson/bson.vcxproj
 logtbl.pyc
 cuckoomon.vcxproj.user
+cuckoomon.vcxproj
 bson/Release
 objects
 Release
@@ -18,3 +20,4 @@ tests/logging-test.*
 *.opendb
 *.VC.db
 .vs/*
+loader/loader/loader.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,8 @@ bson/bson.sdf
 bson/bson.v11.suo
 bson/bson.v12.suo
 bson/bson.vcxproj.user
-bson/bson.vcxproj
 logtbl.pyc
 cuckoomon.vcxproj.user
-cuckoomon.vcxproj
 bson/Release
 objects
 Release
@@ -20,4 +18,3 @@ tests/logging-test.*
 *.opendb
 *.VC.db
 .vs/*
-loader/loader/loader.vcxproj

--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -650,6 +650,8 @@ static hook_t g_hooks[] = {
 	HOOK(cryptsp, CryptEnumProvidersA),
 	HOOK(cryptsp, CryptEnumProvidersW),
 	HOOK(cryptsp, CryptHashSessionKey),
+
+	HOOK(vbe7, rtcEnvironBstr),
 };
 
 void set_hooks_dll(const wchar_t *library)

--- a/cuckoomon.vcxproj
+++ b/cuckoomon.vcxproj
@@ -83,7 +83,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <TargetName>capemon</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSdk_71A_IncludePath);C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\WTL91\Include;</IncludePath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSdk_71A_IncludePath);C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\WTL91\Include</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>true</LinkIncremental>

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1505,8 +1505,10 @@ HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
 	LPWSTR ret = Old_rtcEnvironBstr(es);
 	len = (unsigned int)wcslen(ret);
 	origret = calloc(1, (len + 1) * sizeof(wchar_t));
+	// save the string value
 	wcscpy_s(origret, len + 1, ret);
 
+	// check if environment variable is "userdomain"
 	if (wcsicmp(es->envstr, L"userdomain") == 0) {
 		// replace first character in string with an "_"
 		*ret = 0x5f;

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1499,14 +1499,20 @@ HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
 	struct envstruct *es
 )
 {
+	DoOutputDebugString("DEBUG:Hooking rtcEnvironBstr\n");
+	LPWSTR origret;
+	unsigned int len = 0;
+
 	LPWSTR ret = Old_rtcEnvironBstr(es);
-	LPWSTR origret = ret;
+	len = (unsigned int)wcslen(ret);
+	origret = calloc(1, (len + 1) * sizeof(wchar_t));
+	wcscpy_s(origret, len + 1, ret);
+
 	if (wcsicmp(es->envstr, L"userdomain") == 0) {
 		DoOutputDebugString("DEBUG:VBE call to rtcEnvironBstr - %S = %S\n", es->envstr, ret);
 		*ret = 95;
 	}
-	
-	LOQ_zero("misc", "uu", "EnvVar", es->envstr, "EnvStr", origret);
+	LOQ_bool("misc", "uu", "EnvVar", es->envstr, "EnvStr", origret);
 
 	return ret;
 }

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1508,7 +1508,8 @@ HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
 	wcscpy_s(origret, len + 1, ret);
 
 	if (wcsicmp(es->envstr, L"userdomain") == 0) {
-		*ret = 95;
+		// replace first character in string with an "_"
+		*ret = 0x5f;
 	}
 	LOQ_bool("misc", "uu", "EnvVar", es->envstr, "EnvStr", origret);
 

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1499,21 +1499,12 @@ HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
 	struct envstruct *es
 )
 {
-	LPWSTR origret;
-	unsigned int len = 0;
-
 	LPWSTR ret = Old_rtcEnvironBstr(es);
-	len = (unsigned int)wcslen(ret);
-	origret = calloc(1, (len + 1) * sizeof(wchar_t));
-	// save the string value
-	wcscpy_s(origret, len + 1, ret);
-
+	LOQ_bool("misc", "uu", "EnvVar", es->envstr, "EnvStr", ret);
 	// check if environment variable is "userdomain"
-	if (wcsicmp(es->envstr, L"userdomain") == 0) {
-		// replace first character in string with an "_"
-		*ret = 0x5f;
+	if (!wcsicmp(es->envstr, L"userdomain")) {
+		// replace first character in string with an "#"
+		*ret = 0x23;
 	}
-	LOQ_bool("misc", "uu", "EnvVar", es->envstr, "EnvStr", origret);
-
 	return ret;
 }

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1499,7 +1499,6 @@ HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
 	struct envstruct *es
 )
 {
-	DoOutputDebugString("DEBUG:Hooking rtcEnvironBstr\n");
 	LPWSTR origret;
 	unsigned int len = 0;
 
@@ -1509,7 +1508,6 @@ HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
 	wcscpy_s(origret, len + 1, ret);
 
 	if (wcsicmp(es->envstr, L"userdomain") == 0) {
-		DoOutputDebugString("DEBUG:VBE call to rtcEnvironBstr - %S = %S\n", es->envstr, ret);
 		*ret = 95;
 	}
 	LOQ_bool("misc", "uu", "EnvVar", es->envstr, "EnvStr", origret);

--- a/hooks.h
+++ b/hooks.h
@@ -3031,6 +3031,10 @@ extern HOOKDEF(HRESULT, WINAPI, OleConvertOLESTREAMToIStorage,
 );
 
 extern HOOKDEF(BOOL, WINAPI, ChangeWindowMessageFilter,
-  UINT  message,
-  DWORD dwFlag
+	UINT  message,
+	DWORD dwFlag
+);
+
+extern HOOKDEF(LPWSTR, WINAPI, rtcEnvironBstr,
+	struct envstruct *es
 );

--- a/loader/loader/loader.vcxproj
+++ b/loader/loader/loader.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{52D1444F-0B18-4F98-BC62-3D11046190CC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>loader</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -40,7 +40,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
@@ -77,6 +77,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -123,6 +124,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/misc.h
+++ b/misc.h
@@ -205,3 +205,9 @@ LONG WINAPI cuckoomon_exception_handler(__in struct _EXCEPTION_POINTERS *Excepti
 
 void prevent_module_reloading(PVOID *BaseAddress);
 PVOID test_module_reloading(PVOID *BaseAddress);
+
+struct envstruct {
+	ULONG k;
+	ULONG nullval;
+	LPWSTR envstr;
+};


### PR DESCRIPTION
test against 9e8ff27c09c0a6d43fc616731e05c912 (word doc containing VBE macro that checks for userdomain and computername environment variables, if they match the script prevents execution.
