### PR TITLE
Added hooks for BCryptEncrypt and BCryptDecrypt

### DIFF
--- a/hook_crypto.c
+++ b/hook_crypto.c
@@ -455,20 +455,19 @@ HOOKDEF(SECURITY_STATUS, WINAPI, NCryptEncrypt,
 	return ret;
 }
 
-HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
-	BCRYPT_KEY_HANDLE	hKey,
+HOOKDEF(NTSTATUS, WINAPI, BCryptImportKey,
+	BCRYPT_ALG_HANDLE	hAlgorithm,
+	BCRYPT_KEY_HANDLE	hImportKey,
+	LPCWSTR				pszBlobType,
+	BCRYPT_KEY_HANDLE	*phKey,
+	PUCHAR				pbKeyObject,
+	ULONG				cbKeyObject,
 	PUCHAR				pbInput,
 	ULONG				cbInput,
-	VOID				*pPaddingInfo,
-	PUCHAR				pbIV,
-	ULONG				cbIV,
-	PUCHAR				pbOutput,
-	ULONG				cbOutput,
-	ULONG				*pcbResult,
 	ULONG				dwFlags
 ) {
-	BOOL ret = Old_BCryptEncrypt(hKey, pbInput, cbInput, pPaddingInfo, pbIV, cbIV, pbOutput, cbOutput, pcbResult, dwFlags);
-	LOQ_bool("crypto", "bbhp", "Input", cbInput, pbInput, "IV", cbIV, pbIV, "Flags", dwFlags, "CryptKey", hKey);
+	NTSTATUS ret = Old_BCryptImportKey(hAlgorithm, hImportKey, pszBlobType, phKey, pbKeyObject, cbKeyObject, pbInput, cbInput, dwFlags);
+	LOQ_ntstatus("crypto", "bhp", "KeyBlob", cbInput, pbInput, "Flags", dwFlags, "CryptKey", *phKey);
 	return ret;
 }
 
@@ -484,7 +483,24 @@ HOOKDEF(NTSTATUS, WINAPI, BCryptDecrypt,
 	ULONG				*pcbResult,
 	ULONG				dwFlags
 ) {
-	BOOL ret = Old_BCryptDecrypt(hKey, pbInput, cbInput, pPaddingInfo, pbIV, cbIV, pbOutput, cbOutput, pcbResult, dwFlags);
-	LOQ_bool("crypto", "bbhp", "Output", cbOutput, pbOutput, "IV", cbIV, pbIV, "Flags", dwFlags, "CryptKey", hKey);
+	NTSTATUS ret = Old_BCryptDecrypt(hKey, pbInput, cbInput, pPaddingInfo, pbIV, cbIV, pbOutput, cbOutput, pcbResult, dwFlags);
+	LOQ_ntstatus("crypto", "bbhp", "Output", cbOutput, pbOutput, "IV", cbIV, pbIV, "Flags", dwFlags, "CryptKey", hKey);
+	return ret;
+}
+
+HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
+	BCRYPT_KEY_HANDLE	hKey,
+	PUCHAR				pbInput,
+	ULONG				cbInput,
+	VOID				*pPaddingInfo,
+	PUCHAR				pbIV,
+	ULONG				cbIV,
+	PUCHAR				pbOutput,
+	ULONG				cbOutput,
+	ULONG				*pcbResult,
+	ULONG				dwFlags
+) {
+	NTSTATUS ret = Old_BCryptEncrypt(hKey, pbInput, cbInput, pPaddingInfo, pbIV, cbIV, pbOutput, cbOutput, pcbResult, dwFlags);
+	LOQ_ntstatus("crypto", "bbhp", "Input", cbInput, pbInput, "IV", cbIV, pbIV, "Flags", dwFlags, "CryptKey", hKey);
 	return ret;
 }

--- a/hook_crypto.c
+++ b/hook_crypto.c
@@ -454,3 +454,37 @@ HOOKDEF(SECURITY_STATUS, WINAPI, NCryptEncrypt,
 	LOQ_bool("crypto", "bhp", "Output", cbInput, pbInput, "Flags", dwFlags, "CryptKey", hKey);
 	return ret;
 }
+
+HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
+	BCRYPT_KEY_HANDLE	hKey,
+	PUCHAR				pbInput,
+	ULONG				cbInput,
+	VOID				*pPaddingInfo,
+	PUCHAR				pbIV,
+	ULONG				cbIV,
+	PUCHAR				pbOutput,
+	ULONG				cbOutput,
+	ULONG				*pcbResult,
+	ULONG				dwFlags
+) {
+	BOOL ret = Old_BCryptEncrypt(hKey, pbInput, cbInput, pPaddingInfo, pbIV, cbIV, pbOutput, cbOutput, pcbResult, dwFlags);
+	LOQ_bool("crypto", "bbhp", "Input", cbInput, pbInput, "IV", cbIV, pbIV, "Flags", dwFlags, "CryptKey", hKey);
+	return ret;
+}
+
+HOOKDEF(NTSTATUS, WINAPI, BCryptDecrypt,
+	BCRYPT_KEY_HANDLE	hKey,
+	PUCHAR				pbInput,
+	ULONG				cbInput,
+	VOID				*pPaddingInfo,
+	PUCHAR				pbIV,
+	ULONG				cbIV,
+	PUCHAR				pbOutput,
+	ULONG				cbOutput,
+	ULONG				*pcbResult,
+	ULONG				dwFlags
+) {
+	BOOL ret = Old_BCryptDecrypt(hKey, pbInput, cbInput, pPaddingInfo, pbIV, cbIV, pbOutput, cbOutput, pcbResult, dwFlags);
+	LOQ_bool("crypto", "bbhp", "Output", cbOutput, pbOutput, "IV", cbIV, pbIV, "Flags", dwFlags, "CryptKey", hKey);
+	return ret;
+}

--- a/hooks.c
+++ b/hooks.c
@@ -560,8 +560,9 @@ hook_t full_hooks[] = {
 	HOOK(ncrypt, NCryptImportKey),
 	HOOK(ncrypt, NCryptDecrypt),
 	HOOK(ncrypt, NCryptEncrypt),
-	HOOK(bcrypt, BCryptEncrypt),
+	HOOK(bcrypt, BCryptImportKey),
 	HOOK(bcrypt, BCryptDecrypt),
+	HOOK(bcrypt, BCryptEncrypt),
 	// needed due to the DLL being delay-loaded in some cases
 	HOOK(cryptsp, CryptAcquireContextA),
 	HOOK(cryptsp, CryptAcquireContextW),

--- a/hooks.c
+++ b/hooks.c
@@ -560,6 +560,8 @@ hook_t full_hooks[] = {
 	HOOK(ncrypt, NCryptImportKey),
 	HOOK(ncrypt, NCryptDecrypt),
 	HOOK(ncrypt, NCryptEncrypt),
+	HOOK(bcrypt, BCryptEncrypt),
+	HOOK(bcrypt, BCryptDecrypt),
 	// needed due to the DLL being delay-loaded in some cases
 	HOOK(cryptsp, CryptAcquireContextA),
 	HOOK(cryptsp, CryptAcquireContextW),

--- a/hooks.h
+++ b/hooks.h
@@ -2852,7 +2852,19 @@ HOOKDEF(SECURITY_STATUS, WINAPI, NCryptEncrypt,
 	DWORD			 dwFlags
 );
 
-HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
+HOOKDEF(NTSTATUS, WINAPI, BCryptImportKey,
+	BCRYPT_ALG_HANDLE	hAlgorithm,
+	BCRYPT_KEY_HANDLE	hImportKey,
+	LPCWSTR				pszBlobType,
+	BCRYPT_KEY_HANDLE	*phKey,
+	PUCHAR				pbKeyObject,
+	ULONG				cbKeyObject,
+	PUCHAR				pbInput,
+	ULONG				cbInput,
+	ULONG				dwFlags
+);
+
+HOOKDEF(NTSTATUS, WINAPI, BCryptDecrypt,
 	BCRYPT_KEY_HANDLE	hKey,
 	PUCHAR				pbInput,
 	ULONG				cbInput,
@@ -2865,7 +2877,7 @@ HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
 	ULONG				dwFlags
 );
 
-HOOKDEF(NTSTATUS, WINAPI, BCryptDecrypt,
+HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
 	BCRYPT_KEY_HANDLE	hKey,
 	PUCHAR				pbInput,
 	ULONG				cbInput,

--- a/hooks.h
+++ b/hooks.h
@@ -2852,6 +2852,32 @@ HOOKDEF(SECURITY_STATUS, WINAPI, NCryptEncrypt,
 	DWORD			 dwFlags
 );
 
+HOOKDEF(NTSTATUS, WINAPI, BCryptEncrypt,
+	BCRYPT_KEY_HANDLE	hKey,
+	PUCHAR				pbInput,
+	ULONG				cbInput,
+	VOID				*pPaddingInfo,
+	PUCHAR				pbIV,
+	ULONG				cbIV,
+	PUCHAR				pbOutput,
+	ULONG				cbOutput,
+	ULONG				*pcbResult,
+	ULONG				dwFlags
+);
+
+HOOKDEF(NTSTATUS, WINAPI, BCryptDecrypt,
+	BCRYPT_KEY_HANDLE	hKey,
+	PUCHAR				pbInput,
+	ULONG				cbInput,
+	VOID				*pPaddingInfo,
+	PUCHAR				pbIV,
+	ULONG				cbIV,
+	PUCHAR				pbOutput,
+	ULONG				cbOutput,
+	ULONG				*pcbResult,
+	ULONG				dwFlags
+);
+
 //
 // Special Hooks
 //


### PR DESCRIPTION
The new version of Emotet uses bcrypt.dll to encrypt/decrypt stuff, so adding coverage for BCryptEncrypt and BCryptDecrypt.

Other bcrypt.dll API calls used by Emotet (for possible future API hooks):
```
BCryptOpenAlgorithmProvider
BCryptFinalizeKeyPair
BCryptGetProperty
BCryptDecrypt
BCryptCloseAlgorithmProvider
BCryptImportKeyPair
BCryptDestroyKey
BCryptDestroySecret
BCryptGenRandom
BCryptDeriveKey
BCryptImportKey
BCryptHashData
BCryptExportKey
BCryptFinishHash
BCryptSecretAgreement
BCryptCreateHash
BCryptGenerateKeyPair
BCryptDestroyHash
BCryptEncrypt
BCryptVerifySignature
```
