### PR TITLE
Adding safety checks, initialization and error handling

### DIFF
--- a/CAPE/CAPE.c
+++ b/CAPE/CAPE.c
@@ -337,10 +337,19 @@ PVOID GetAllocationBase(PVOID Address)
 		ErrorOutput("GetAllocationBase: Failed to obtain system page size.\n");
 		return 0;
 	}
-
+	__try
+	{
 	if (!VirtualQuery(Address, &MemInfo, sizeof(MEMORY_BASIC_INFORMATION)))
 	{
-		//ErrorOutput("GetAllocationBase: unable to query memory address 0x%p", Address);
+			dw = GetLastError();
+			ErrorOutput("GetAllocationBase: unable to query memory address 0x%p with error %ld", Address, dw);
+		return 0;
+	}
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) 
+	{
+		dw = GetLastError();
+		ErrorOutput("GetAllocationBase: unable to query memory address 0x%p with error %ld", Address, dw);
 		return 0;
 	}
 
@@ -809,10 +818,15 @@ PTRACKEDREGION AddTrackedRegion(PVOID Address, ULONG Protect)
 	{
 		PageAlreadyTracked = TRUE;
 #ifdef DEBUG_COMMENTS
+		if(TrackedRegion)
 		DebugOutput("AddTrackedRegion: Region at 0x%p already in tracked region 0x%p - updating.\n", Address, TrackedRegion->AllocationBase);
 #endif
 	}
-
+	if (!TrackedRegion)
+	{
+		ErrorOutput("AddTrackedRegion: unable to query next tracked region around 0x%p", Address);
+		return NULL;
+	}
 	if (!VirtualQuery(Address, &TrackedRegion->MemInfo, sizeof(MEMORY_BASIC_INFORMATION)))
 	{
 		ErrorOutput("AddTrackedRegion: unable to query memory region 0x%p", Address);
@@ -1515,7 +1529,7 @@ SIZE_T ScanForAccess(PVOID Buffer, SIZE_T Size)
 //**************************************************************************************
 {
 	SIZE_T p, AllocationSize;
-	char c;
+	char c = 0;
 
 	if (!Buffer)
 	{

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1274,13 +1274,13 @@ HOOKDEF(HRSRC, WINAPI, FindResourceExW,
 
 	wchar_t type_id[8];
 	if (IS_INTRESOURCE(lpType)) {
-		swprintf(type_id, sizeof type_id, L"#%hu", (WORD)lpType);
+		swprintf_s(type_id, sizeof(type_id), L"#%hu", (WORD)lpType);
 		lpType = type_id;
 	}
 
 	wchar_t name_id[8];
 	if (IS_INTRESOURCE(lpName)) {
-		swprintf(name_id, sizeof name_id, L"#%hu", (WORD)lpName);
+		swprintf_s(name_id, sizeof(name_id), L"#%hu", (WORD)lpName);
 		lpName = name_id;
 	}
 

--- a/hook_process.c
+++ b/hook_process.c
@@ -199,11 +199,20 @@ HOOKDEF(BOOL, WINAPI, CreateProcessW,
 	__out	    LPPROCESS_INFORMATION lpProcessInformation
 ) {
 	BOOL ret;
+	lasterror_t lasterror;
 	ENSURE_STRUCT(lpProcessInformation, PROCESS_INFORMATION);
-
+	__try
+	{
 	ret = Old_CreateProcessW(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes,
 		bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation);
-
+	}
+	__except(EXCEPTION_EXECUTE_HANDLER) 
+	{
+		get_lasterrors(&lasterror);
+		if(&lasterror)
+			DebugOutput("Error creating process %ls with error: Win:%lu NT:%lu ",lpCommandLine,lasterror.Win32Error,lasterror.NtstatusError);
+		set_lasterrors(&lasterror);
+	}
 	if (dwCreationFlags & EXTENDED_STARTUPINFO_PRESENT && lpStartupInfo->cb == sizeof(STARTUPINFOEXW)) {
 		HANDLE ParentHandle = (HANDLE)-1;
 		unsigned int i;

--- a/hook_reg.c
+++ b/hook_reg.c
@@ -300,7 +300,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyW,
 
 		for (i = 0, j = 0; i < _countof(parent_keys); i += 1, j += 2) {
 			if (!wcsicmp(keypath, parent_keys[i]) && !wcsicmp(lpName, replace_subkeys[j])) {
-				wcscpy(lpName, replace_subkeys[j + 1]);
+				wcscpy_s(lpName, sizeof(lpName), replace_subkeys[j + 1]);
 				break;
 			}
 		}
@@ -348,7 +348,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyExA,
 
 		for (i = 0, j = 0; i < _countof(parent_keys); i += 1, j += 2) {
 			if (!wcsicmp(keypath, parent_keys[i]) && !stricmp(lpName, replace_subkeys[j])) {
-				strcpy(lpName, replace_subkeys[j + 1]);
+				strcpy_s(lpName, sizeof(lpName), replace_subkeys[j + 1]);
 				break;
 			}
 		}
@@ -398,7 +398,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyExW,
 
 		for (i = 0, j = 0; i < _countof(parent_keys); i += 1, j += 2) {
 			if (!wcsicmp(keypath, parent_keys[i]) && !wcsicmp(lpName, replace_subkeys[j])) {
-				wcscpy(lpName, replace_subkeys[j + 1]);
+				wcscpy_s(lpName, sizeof(lpName), replace_subkeys[j + 1]);
 				break;
 			}
 		}

--- a/hooking.c
+++ b/hooking.c
@@ -385,11 +385,16 @@ hook_info_t *hook_info()
 
 void get_lasterrors(lasterror_t *errors)
 {
-	char *teb;
+	char *teb = NULL;
 
 	errors->Eflags = (DWORD)__readeflags();
 
 	teb = (char *)NtCurrentTeb();
+
+	if(teb == NULL)
+		errors->Win32Error = -1;
+		errors->NtstatusError = -1;
+		return
 
 	errors->Win32Error = *(DWORD *)(teb + TLS_LAST_WIN32_ERROR);
 	errors->NtstatusError = *(DWORD *)(teb + TLS_LAST_NTSTATUS_ERROR);
@@ -399,6 +404,9 @@ void get_lasterrors(lasterror_t *errors)
 void set_lasterrors(lasterror_t *errors)
 {
 	char *teb = (char *)NtCurrentTeb();
+
+	if(teb == NULL)
+		return
 
 	*(DWORD *)(teb + TLS_LAST_WIN32_ERROR) = errors->Win32Error;
 	*(DWORD *)(teb + TLS_LAST_NTSTATUS_ERROR) = errors->NtstatusError;

--- a/log.c
+++ b/log.c
@@ -155,7 +155,7 @@ static void log_raw_direct(const char *buf, size_t length) {
 	while (copiedlen != length) {
 		EnterCriticalSection(&g_writing_log_buffer_mutex);
 		copylen = min(length - copiedlen, (size_t)(BUFFERSIZE - g_idx));
-		memcpy(&g_buffer[g_idx], &buf[copiedlen], copylen);
+		if(g_buffer) memcpy(&g_buffer[g_idx], &buf[copiedlen], copylen); 
 		g_idx += (int)copylen;
 		copiedlen += copylen;
 		LeaveCriticalSection(&g_writing_log_buffer_mutex);


### PR DESCRIPTION
CAPE/CAPE.c 
PVOID GetAllocationBase(PVOID Address) was found to fail silently since the erroroutput have been commented out. At VirtualQuery(Address, &MemInfo, sizeof(MEMORY_BASIC_INFORMATION), getting the last error can be really helpful to troubleshoot and the try catch mechanism could be a good catch point.  

A missing TrackedRegion give error in the logging so the if statement have been added to prevent that from happening and appropriate logging have been added to make sure the lack of it is not silently passed.

In SIZE_T ScanForAccess(PVOID Buffer, SIZE_T Size), the char c is not initialized if the try catch fail and therefore the debugoutput could be erronous. 

hook_misc.c
The usage of swprintf_s is prefered over swprintf for the added security feature into it. 

hook_process.c
Error handling propagation to one more hook.

hook_reg.c
Adding safety with wcscpy_s and strcpy_s as good practice.

hook_special.c
Adding more CLSID for BITS and initializint the CLSID to empty value.

hooking.c
Prevent teb empty value on NtCurrentTeb failure if possible. 

