### PR TITLE
add EnumDisplayDevices hook

### DIFF
--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1816,7 +1816,7 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesA,
 			break;
 		}
 	}
-	LOQ_bool("misc", "s", "NewDeviceString", lpDisplayDevice->DeviceString);
+	LOQ_bool("misc", "s", "DeviceString", lpDisplayDevice->DeviceString);
 	return ret;
 }
 
@@ -1841,6 +1841,6 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
 			break;
 		}
 	}
-	LOQ_bool("misc", "u", "NewDeviceString", lpDisplayDevice->DeviceString);
+	LOQ_bool("misc", "u", "DeviceString", lpDisplayDevice->DeviceString);
 	return ret;
 }

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1813,10 +1813,10 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesA,
 	for (int i = 0; i < keywords_size; i++) {
 		if (stristr(lpDisplayDevice->DeviceString, keywords[i]) != NULL) {
 			snprintf(lpDisplayDevice->DeviceString, 128, "NVIDIA GeForce GPU");
-			LOQ_bool("misc", "s", "NewDeviceString", lpDisplayDevice->DeviceString);
 			break;
 		}
 	}
+	LOQ_bool("misc", "s", "NewDeviceString", lpDisplayDevice->DeviceString);
 	return ret;
 }
 
@@ -1838,9 +1838,9 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
 	for (int i = 0; i < keywords_size; i++) {
 		if (wcsistr(lpDisplayDevice->DeviceString, keywords[i]) != NULL) {
 			swprintf(lpDisplayDevice->DeviceString, 128, L"NVIDIA GeForce GPU");
-			LOQ_bool("misc", "u", "NewDeviceString", lpDisplayDevice->DeviceString);
 			break;
 		}
 	}
+	LOQ_bool("misc", "u", "NewDeviceString", lpDisplayDevice->DeviceString);
 	return ret;
 }

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1800,9 +1800,23 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesA,
 	_Out_   PDISPLAY_DEVICEA lpDisplayDevice,
 	_In_	DWORD  dwFlags
 ) {
+	const char* keywords[] = {
+		"microsoft hyper-v video",
+		"virtual",
+		"vmware",
+		"standard vga graphics adapter",
+		"microsoft basic display adapter"
+	};
+
+	int keywords_size = sizeof(keywords) / sizeof(keywords[0]);
 	BOOL ret = Old_EnumDisplayDevicesA(lpDevice, iDevNum, lpDisplayDevice, dwFlags);
-	snprintf(lpDisplayDevice->DeviceString, 128, "Super Advanced Display Adapter");
-	LOQ_bool("misc", "s", "NewDeviceString", lpDisplayDevice->DeviceString);
+	for (int i = 0; i < keywords_size; i++) {
+		if (stristr(lpDisplayDevice->DeviceString, keywords[i]) != NULL) {
+			snprintf(lpDisplayDevice->DeviceString, 128, "NVIDIA GeForce GPU");
+			LOQ_bool("misc", "s", "NewDeviceString", lpDisplayDevice->DeviceString);
+			break;
+		}
+	}
 	return ret;
 }
 
@@ -1812,8 +1826,21 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
 	_Out_   PDISPLAY_DEVICEW lpDisplayDevice,
 	_In_	DWORD  dwFlags
 ) {
+	const wchar_t* keywords[] = {
+		L"microsoft hyper-v video",
+		L"virtual",
+		L"vmware",
+		L"standard vga graphics adapter",
+		L"microsoft basic display adapter"
+	};
+	int keywords_size = sizeof(keywords) / sizeof(keywords[0]);
 	BOOL ret = Old_EnumDisplayDevicesW(lpDevice, iDevNum, lpDisplayDevice, dwFlags);
-	swprintf(lpDisplayDevice->DeviceString, 128, L"Super Advanced Display Adapter");
-	LOQ_bool("misc", "u", "NewDeviceString", lpDisplayDevice->DeviceString);
+	for (int i = 0; i < keywords_size; i++) {
+		if (wcsistr(lpDisplayDevice->DeviceString, keywords[i]) != NULL) {
+			swprintf(lpDisplayDevice->DeviceString, 128, L"NVIDIA GeForce GPU");
+			LOQ_bool("misc", "u", "NewDeviceString", lpDisplayDevice->DeviceString);
+			break;
+		}
+	}
 	return ret;
 }

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1793,3 +1793,27 @@ HOOKDEF(LPWSTR, WINAPI, GetCommandLineW,
 	LOQ_nonnull("misc", "u", "CommandLine", ret);
 	return ret;
 }
+
+HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesA,
+	_In_	LPCSTR  lpDevice,
+	_In_	DWORD  iDevNum,
+	_Out_   PDISPLAY_DEVICEA lpDisplayDevice,
+	_In_	DWORD  dwFlags
+) {
+	BOOL ret = Old_EnumDisplayDevicesA(lpDevice, iDevNum, lpDisplayDevice, dwFlags);
+	snprintf(lpDisplayDevice->DeviceString, 128, "Super Advanced Display Adapter");
+	LOQ_bool("misc", "s", "NewDeviceString", lpDisplayDevice->DeviceString);
+	return ret;
+}
+
+HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
+	_In_	LPCWSTR  lpDevice,
+	_In_	DWORD  iDevNum,
+	_Out_   PDISPLAY_DEVICEW lpDisplayDevice,
+	_In_	DWORD  dwFlags
+) {
+	BOOL ret = Old_EnumDisplayDevicesW(lpDevice, iDevNum, lpDisplayDevice, dwFlags);
+	swprintf(lpDisplayDevice->DeviceString, 128, L"Super Advanced Display Adapter");
+	LOQ_bool("misc", "u", "NewDeviceString", lpDisplayDevice->DeviceString);
+	return ret;
+}

--- a/hooks.c
+++ b/hooks.c
@@ -235,6 +235,8 @@ hook_t full_hooks[] = {
 	HOOK(user32, SetWindowLongW),
 	HOOK(user32, SetWindowLongPtrA),
 	HOOK(user32, SetWindowLongPtrW),
+	HOOK(user32, EnumDisplayDevicesA),
+	HOOK(user32, EnumDisplayDevicesW),
 //	HOOK_NOTAIL(user32, CreateWindowExA, 12),	// maldoc detonation issues
 //	HOOK_NOTAIL(user32, CreateWindowExW, 12),	//
 //	HOOK(user32, EnumWindows),	// Disable for now, invokes a user-specified callback that can contain

--- a/hooks.h
+++ b/hooks.h
@@ -3526,3 +3526,17 @@ HOOKDEF(int, WINAPI, compileMethod,
 	uint8_t**		entryAddress,
 	uint32_t*		nativeSizeOfCode
 );
+
+HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesA,
+	_In_	LPCSTR  lpDevice,
+	_In_	DWORD   iDevNum,
+	_Out_   PDISPLAY_DEVICEA lpDisplayDevice,
+	_In_	DWORD   dwFlags
+);
+
+HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
+	_In_	LPCWSTR  lpDevice,
+	_In_	DWORD    iDevNum,
+	_Out_   PDISPLAY_DEVICEW lpDisplayDevice,
+	_In_	DWORD    dwFlags
+);

--- a/misc.c
+++ b/misc.c
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdio.h>
 #include <ctype.h>
+#include <wctype.h>
 #include "ntapi.h"
 #include <Psapi.h>
 #include <shlwapi.h>
@@ -258,7 +259,7 @@ void replace_ci_wstring_in_buf(PWCHAR buf, ULONG len, PWCHAR findstr, PWCHAR rep
 }
 
 // https://stackoverflow.com/questions/27303062/strstr-function-like-that-ignores-upper-or-lower-case
-char* stristr(char* haystack, char* needle) {
+char* stristr(char* haystack, const char* needle) {
 	int c = tolower(*needle);
 	if (c == '\0')
 		return haystack;
@@ -268,6 +269,23 @@ char* stristr(char* haystack, char* needle) {
 				if (needle[++i] == '\0')
 					return haystack;
 				if (tolower(haystack[i]) != tolower(needle[i]))
+					break;
+			}
+		}
+	}
+	return NULL;
+}
+
+wchar_t* wcsistr(wchar_t* haystack, const wchar_t* needle) {
+	wint_t c = towlower(*needle);
+	if (c == L'\0')
+		return haystack;
+	for (; *haystack; haystack++) {
+		if (towlower(*haystack) == c) {
+			for (size_t i = 0;;) {
+				if (needle[++i] == L'\0')
+					return haystack;
+				if (towlower(haystack[i]) != towlower(needle[i]))
 					break;
 			}
 		}

--- a/misc.h
+++ b/misc.h
@@ -235,7 +235,8 @@ void replace_ci_wstring_in_buf(PWCHAR buf, ULONG len, PWCHAR findstr, PWCHAR rep
 void perform_ascii_registry_fakery(PWCHAR keypath, LPVOID Data, ULONG DataLength);
 void perform_unicode_registry_fakery(PWCHAR keypath, LPVOID Data, ULONG DataLength);
 void perform_device_fakery(PVOID OutputBuffer, ULONG OutputBufferLength, ULONG IoControlCode);
-char* stristr(char* haystack, char* needle);
+char* stristr(char* haystack, const char* needle);
+wchar_t* wcsistr(wchar_t* haystack, const wchar_t* needle);
 unsigned short our_htons(unsigned short num);
 unsigned int our_htonl(unsigned int num);
 void addr_to_string(const IN_ADDR addr, char *string);


### PR DESCRIPTION
Sets the DeviceString for the first display device returned to "Super Advanced Display Adapter" to thwart anti-vm  