### PR TITLE
Add RmStartSession hook

### DIFF
--- a/capemon.vcxproj
+++ b/capemon.vcxproj
@@ -42,10 +42,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <UseOfMfc>false</UseOfMfc>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -30,6 +30,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "CAPE\Injection.h"
 #include "CAPE\Debugger.h"
 #include "CAPE\YaraHarness.h"
+#include <RestartManager.h>
+#pragma comment(lib ,"Rstrtmgr.lib")
 
 #define STATUS_BAD_COMPRESSION_BUFFER ((NTSTATUS)0xC0000242L)
 
@@ -670,6 +672,17 @@ HOOKDEF(SHORT, WINAPI, GetAsyncKeyState,
 		asynckeystate_logcount++;
 		LOQ_nonzero("windows", "is", "KeyCode", vKey, "Status", "Log limit reached");
 	}
+	return ret;
+}
+
+HOOKDEF(DWORD, WINAPI, RmStartSession,
+	__out DWORD *pSessionHandle,
+	_Reserved_ DWORD dwSessionFlags,
+	__out WCHAR strSessionKey[]
+) {
+	DWORD ret = Old_RmStartSession(pSessionHandle, dwSessionFlags, strSessionKey);
+
+	LOQ_ntstatus("misc", "u", "SessionKey", strSessionKey);
 	return ret;
 }
 

--- a/hooks.c
+++ b/hooks.c
@@ -20,6 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "hooking.h"
 #include "hooks.h"
 
+#pragma comment(lib ,"Rstrtmgr.lib")
+
+
 extern VOID CALLBACK New_DllLoadNotification(ULONG NotificationReason, const PLDR_DLL_NOTIFICATION_DATA NotificationData, PVOID Context);
 extern void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
 extern void ErrorOutput(_In_ LPCTSTR lpOutputString, ...);
@@ -361,6 +364,7 @@ hook_t full_hooks[] = {
 	HOOK(advapi32, GetUserNameA),
 	HOOK(advapi32, GetUserNameW),
 	HOOK(user32, GetAsyncKeyState),
+	HOOK(rstrtmgr, RmStartSession),
 	HOOK(ntdll, NtLoadDriver),
 	HOOK(ntdll, NtSetInformationProcess),
 	//HOOK(ntdll, NtQueryInformationProcess),

--- a/hooks.h
+++ b/hooks.h
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ntapi.h"
 #include <tlhelp32.h>
 #include <ncrypt.h>
+#include <RestartManager.h>
+#pragma comment(lib ,"Rstrtmgr.lib")
 
 //
 // File Hooks
@@ -1627,6 +1629,12 @@ HOOKDEF(NTSTATUS, WINAPI, NtLoadDriver,
 
 HOOKDEF(SHORT, WINAPI, GetAsyncKeyState,
 	__in int vKey
+);
+
+HOOKDEF(DWORD, WINAPI, RmStartSession,
+	__out DWORD* pSessionHandle,
+	DWORD   dwSessionFlags,
+	__out WCHAR strSessionKey[]
 );
 
 HOOKDEF(HHOOK, WINAPI, SetWindowsHookExA,


### PR DESCRIPTION
During software updates, certain files may be locked by active applications, hindering the update process from making modifications. The Restart Manager, a library (“RstrtMgr.dll”), enables applications to shut down processes locking resources without requiring a system reboot.

According to [CrowdStrike](https://www.crowdstrike.com/en-us/blog/windows-restart-manager-part-2/), malware may exploit the Restart Manager in ransomware activities to unlock files for encryption or perform process discovery directly in memory.

By utilizing RmStartSession, we can detect if malware is enumerating the filesystem, create a session key for each file, and establish a threshold for the number of sessions designed to identify potential malicious activity.