### PR TITLE
Fixed the bug where the entry point was incorrect during the import reconstruction

### DIFF
--- a/CAPE/Scylla/ImportRebuilder.cpp
+++ b/CAPE/Scylla/ImportRebuilder.cpp
@@ -17,7 +17,7 @@ New Scylla section contains:
 extern "C" void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
 extern "C" void ErrorOutput(_In_ LPCTSTR lpOutputString, ...);
 
-bool ImportRebuilder::rebuildImportTable(const CHAR * newFilePath, std::map<DWORD_PTR, ImportModuleThunk> & moduleList)
+bool ImportRebuilder::rebuildImportTable(const CHAR * newFilePath, std::map<DWORD_PTR, ImportModuleThunk> & moduleList, DWORD_PTR entryPoint)
 {
 	std::map<DWORD_PTR, ImportModuleThunk> copyModule;
 	copyModule.insert(moduleList.begin(), moduleList.end());

--- a/CAPE/Scylla/ImportRebuilder.cpp
+++ b/CAPE/Scylla/ImportRebuilder.cpp
@@ -60,7 +60,7 @@ bool ImportRebuilder::rebuildImportTable(const CHAR * newFilePath, std::map<DWOR
 	DebugOutput("ImportRebuilder::rebuildImportTable: Successfully built new import table, saving fixed file to disk.\n");
 #endif
 
-	return (savePeFileToDisk(newFilePath));
+	return (savePeFileToDisk(newFilePath, entryPoint));
 }
 
 bool ImportRebuilder::buildNewImportTable(std::map<DWORD_PTR, ImportModuleThunk> & moduleList)

--- a/CAPE/Scylla/ImportRebuilder.h
+++ b/CAPE/Scylla/ImportRebuilder.h
@@ -42,7 +42,7 @@ public:
 		sizeOfJumpTable = 0;
 	}
 
-	bool rebuildImportTable(const CHAR * newFilePath, std::map<DWORD_PTR, ImportModuleThunk> & moduleList);
+	bool rebuildImportTable(const CHAR * newFilePath, std::map<DWORD_PTR, ImportModuleThunk> & moduleList, DWORD_PTR entryPoint);
 	void enableOFTSupport();
 	void enableNewIatInSection(DWORD_PTR iatAddress, DWORD iatSize);
 

--- a/CAPE/Scylla/PeParser.cpp
+++ b/CAPE/Scylla/PeParser.cpp
@@ -934,6 +934,16 @@ DWORD PeParser::isMemoryNotNull( BYTE * data, int dataSize )
 	return 0;
 }
 
+bool PeParser::savePeFileToDisk(const CHAR *newFile, DWORD_PTR entryPoint)
+{
+	if (entryPoint)
+	{
+		DebugOutput("DumpProcess: Setting entrypoint to 0x%p.\n", entryPoint);
+		setEntryPointVa(entryPoint);
+	}
+	return savePeFileToDisk(newFile);
+}
+
 bool PeParser::savePeFileToDisk(const CHAR *newFile)
 {
 	bool retValue = true, SectionDataWritten = false;

--- a/CAPE/Scylla/PeParser.h
+++ b/CAPE/Scylla/PeParser.h
@@ -72,6 +72,7 @@ public:
 	bool readPeSectionsFromProcess();
 	bool readPeSectionsFromFile();
 	bool savePeFileToDisk(const CHAR * newFile);
+	bool savePeFileToDisk(const CHAR *newFile, DWORD_PTR entryPoint);
 	bool savePeFileToHandle(HANDLE FileHandle);
 	bool saveCompletePeToDisk(const CHAR * newFile);
 	bool saveCompletePeToHandle(HANDLE FileHandle);

--- a/CAPE/ScyllaHarness.cpp
+++ b/CAPE/ScyllaHarness.cpp
@@ -380,7 +380,7 @@ extern "C" int ScyllaDumpProcess(HANDLE hProcess, DWORD_PTR ModuleBase, DWORD_PT
 				importRebuild.enableNewIatInSection(addressIAT, sizeIAT);
 			}
 
-			if (importRebuild.rebuildImportTable(NULL, importsHandling.moduleList))
+			if (importRebuild.rebuildImportTable(NULL, importsHandling.moduleList, entrypoint))
 			{
 				DebugOutput("DumpProcess: Import table rebuild success.\n");
 				delete peFile;


### PR DESCRIPTION
I noticed that entry point was incorrect during the import reconstruction because entrypoint value was not passed into the PeParser.I made some modifications and submitted the code. Please check if there are any problems.