### PR TITLE
Add hooks for MsiInstallProductA/W

### DIFF
--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1913,3 +1913,21 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
 	LOQ_bool("misc", "u", "DeviceString", lpDisplayDevice->DeviceString);
 	return ret;
 }
+
+HOOKDEF(UINT, WINAPI, MsiInstallProductA,
+	_In_	LPCSTR	szPackagePath,
+	_In_	LPCSTR	szCommandLine
+) {
+	UINT ret = Old_MsiInstallProductA(szPackagePath, szCommandLine);
+	LOQ_zero("misc", "ss", "PackagePath", szPackagePath, "CommandLine", szCommandLine);
+	return ret;
+}
+
+HOOKDEF(UINT, WINAPI, MsiInstallProductW,
+	_In_	LPCWSTR	szPackagePath,
+	_In_	LPCWSTR	szCommandLine
+) {
+	UINT ret = Old_MsiInstallProductW(szPackagePath, szCommandLine);
+	LOQ_zero("misc", "uu", "PackagePath", szPackagePath, "CommandLine", szCommandLine);
+	return ret;
+}

--- a/hooks.c
+++ b/hooks.c
@@ -298,6 +298,8 @@ hook_t full_hooks[] = {
 	HOOK(user32, SetWindowLongPtrW),
 	HOOK(user32, EnumDisplayDevicesA),
 	HOOK(user32, EnumDisplayDevicesW),
+	HOOK(msi, MsiInstallProductA),
+	HOOK(msi, MsiInstallProductW),
 //	HOOK_NOTAIL(user32, CreateWindowExA, 12),	// maldoc detonation issues
 //	HOOK_NOTAIL(user32, CreateWindowExW, 12),	//
 //	HOOK(user32, EnumWindows),	// Disable for now, invokes a user-specified callback that can contain

--- a/hooks.h
+++ b/hooks.h
@@ -3638,4 +3638,14 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
 	_In_	DWORD    dwFlags
 );
 
+HOOKDEF(UINT, WINAPI, MsiInstallProductA,
+	_In_	LPCSTR	szPackagePath,
+	_In_	LPCSTR	szCommandLine
+);
+
+HOOKDEF(UINT, WINAPI, MsiInstallProductW,
+	_In_	LPCWSTR	szPackagePath,
+	_In_	LPCWSTR	szCommandLine
+);
+
 #include "hook_vbscript.h"


### PR DESCRIPTION
This more easily surfaces package paths (which can be URLs) in behavior logs. You won't need to deobfuscate WSH JS/VBS to get strings passed to WindowsInstaller.Installer->InstallProduct