### PR TITLE
Fixed the bug where the program crashed due to the presence of "?.DLL” after import reconstruction

### DIFF
--- a/CAPE/Scylla/ApiReader.cpp
+++ b/CAPE/Scylla/ApiReader.cpp
@@ -985,7 +985,7 @@ void ApiReader::parseIAT(DWORD_PTR addressIAT, BYTE * iatBuffer, SIZE_T size)
 				else
 				{
 					countApiNotFound++;
-					addNotFoundApiToModuleList(addressIAT + (DWORD_PTR)&pIATAddress[i] - (DWORD_PTR)iatBuffer, pIATAddress[i]);
+					//addNotFoundApiToModuleList(addressIAT + (DWORD_PTR)&pIATAddress[i] - (DWORD_PTR)iatBuffer, pIATAddress[i]);
 #ifdef DEBUG_COMMENTS
 					DebugOutput("parseIAT: API not found %08X\n", pIATAddress[i]);
 #endif
@@ -997,7 +997,7 @@ void ApiReader::parseIAT(DWORD_PTR addressIAT, BYTE * iatBuffer, SIZE_T size)
 				DebugOutput("parseIAT: API not found %08X\n", pIATAddress[i]);
 #endif
 				countApiNotFound++;
-				addNotFoundApiToModuleList(addressIAT + (DWORD_PTR)&pIATAddress[i] - (DWORD_PTR)iatBuffer, pIATAddress[i]);
+				//addNotFoundApiToModuleList(addressIAT + (DWORD_PTR)&pIATAddress[i] - (DWORD_PTR)iatBuffer, pIATAddress[i]);
 			}
 		}
 


### PR DESCRIPTION
Although I don't know why "?.DLL" appeared — it shouldn't have been in the IAT in the first place. So, when I commented out `addNotFoundApiToModuleList` , the "?.DLL" no longer appeared, and the program ran normally. I think if an API is not found, it should not be added to the `modulelist`. This approach would prevent invalid entries like "?.DLL" from causing crashes in the repaired program. #90 