### PR TITLE
Hook CryptDuplicateKey

### DIFF
--- a/hook_crypto.c
+++ b/hook_crypto.c
@@ -278,16 +278,29 @@ HOOKDEF(BOOL, WINAPI, CryptDeriveKey,
 }
 
 HOOKDEF(BOOL, WINAPI, CryptExportKey,
-	_In_	 HCRYPTKEY hKey,
-	_In_	 HCRYPTKEY hExpKey,
-	_In_	 DWORD dwBlobType,
-	_In_	 DWORD dwFlags,
+	_In_	HCRYPTKEY hKey,
+	_In_	HCRYPTKEY hExpKey,
+	_In_	DWORD dwBlobType,
+	_In_	DWORD dwFlags,
 	_Out_	BYTE *pbData,
-	_Inout_  DWORD *pdwDataLen
+	_Inout_	DWORD *pdwDataLen
 ) {
 	BOOL ret = Old_CryptExportKey(hKey, hExpKey, dwBlobType, dwFlags, pbData, pdwDataLen);
 	if (pbData && pdwDataLen)
 		LOQ_bool("crypto", "pbihi", "CryptKey", hKey, "Buffer", *pdwDataLen, pbData, "BlobType", dwBlobType, "Flags", dwFlags, "Length", *pdwDataLen);
+	return ret;
+}
+
+HOOKDEF(BOOL, WINAPI, CryptDuplicateKey,
+	_In_	HCRYPTKEY	hKey,
+	_In_	DWORD* pdwReserved,
+	_In_	DWORD		dwFlags,
+	_Out_	HCRYPTKEY* phKey
+) {
+	BOOL ret = Old_CryptDuplicateKey(hKey, pdwReserved, dwFlags, phKey);
+	if (ret) {
+		LOQ_bool("crypto", "pph", "OldCryptKey", hKey, "NewCryptKey", *phKey, "Flags", dwFlags);
+	}
 	return ret;
 }
 

--- a/hooks.h
+++ b/hooks.h
@@ -2974,6 +2974,13 @@ HOOKDEF(BOOL, WINAPI, CryptExportKey,
 	_Inout_  DWORD *pdwDataLen
 );
 
+HOOKDEF(BOOL, WINAPI, CryptDuplicateKey,
+	_In_	HCRYPTKEY	hKey,
+	_In_	DWORD* pdwReserved,
+	_In_	DWORD		dwFlags,
+	_Out_	HCRYPTKEY* phKey
+);
+
 HOOKDEF(BOOL, WINAPI, CryptDestroyKey,
 	_In_   HCRYPTKEY hKey
 );


### PR DESCRIPTION
Allows ability to properly track CryptKey handles (.NET often times operates on dupe key instead of original)