### PR TITLE
Improve log args for a few hooks:

### DIFF
--- a/hook_process.c
+++ b/hook_process.c
@@ -976,7 +976,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtWriteVirtualMemory,
 
 	pid = pid_from_process_handle(ProcessHandle);
 
-	if (pid != GetCurrentProcess()) {
+	if (pid != GetCurrentProcessId()) {
 		LOQ_ntstatus(
 			"process", "pipBhs",
 			"ProcessHandle", ProcessHandle,
@@ -1024,7 +1024,7 @@ HOOKDEF(BOOL, WINAPI, WriteProcessMemory,
 
 	pid = pid_from_process_handle(hProcess);
 
-	if (pid != GetCurrentProcess()) {
+	if (pid != GetCurrentProcessId()) {
 		LOQ_bool(
 			"process", "pipBhs",
 			"ProcessHandle", hProcess,

--- a/hook_process.c
+++ b/hook_process.c
@@ -898,8 +898,27 @@ HOOKDEF(NTSTATUS, WINAPI, NtReadVirtualMemory,
 	ENSURE_SIZET(NumberOfBytesRead);
 
 	ret = Old_NtReadVirtualMemory(ProcessHandle, BaseAddress, Buffer, NumberOfBytesToRead, NumberOfBytesRead);
+	DWORD pid = pid_from_process_handle(ProcessHandle);
 
-	LOQ_ntstatus("process", "pphB", "ProcessHandle", ProcessHandle, "BaseAddress", BaseAddress, "Size", NumberOfBytesToRead, "Buffer", NumberOfBytesRead, Buffer);
+	if (pid != GetCurrentProcessId()) {
+		LOQ_ntstatus(
+			"process", "piphB",
+			"ProcessHandle", ProcessHandle,
+			"ProcessId", pid,
+			"BaseAddress", BaseAddress,
+			"Size", NumberOfBytesToRead,
+			"Buffer", NumberOfBytesRead, Buffer
+		);
+	}
+	else {
+		LOQ_ntstatus(
+			"process", "piphB",
+			"ProcessHandle", ProcessHandle,
+			"BaseAddress", BaseAddress,
+			"Size", NumberOfBytesToRead,
+			"Buffer", NumberOfBytesRead, Buffer
+		);
+	}
 
 	return ret;
 }
@@ -915,8 +934,28 @@ HOOKDEF(BOOL, WINAPI, ReadProcessMemory,
 	ENSURE_SIZET(lpNumberOfBytesRead);
 
 	ret = Old_ReadProcessMemory(hProcess, lpBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead);
+	DWORD pid = pid_from_process_handle(hProcess);
 
-	LOQ_bool("process", "pphB", "ProcessHandle", hProcess, "BaseAddress", lpBaseAddress, "Size", nSize, "Buffer", lpNumberOfBytesRead, lpBuffer);
+	if (pid != GetCurrentProcessId()) {
+		LOQ_bool(
+			"process", "pphB",
+			"ProcessHandle", hProcess,
+			"BaseAddress", lpBaseAddress,
+			"Size", nSize,
+			"Buffer", lpNumberOfBytesRead, lpBuffer,
+			"ProcessId", pid
+		);
+	}
+	else {
+		LOQ_bool(
+			"process", "pphB",
+			"ProcessHandle", hProcess,
+			"BaseAddress", lpBaseAddress,
+			"Size", nSize,
+			"Buffer", lpNumberOfBytesRead, lpBuffer,
+			"ProcessId", pid
+		);
+	}
 
 	return ret;
 }
@@ -937,12 +976,27 @@ HOOKDEF(NTSTATUS, WINAPI, NtWriteVirtualMemory,
 
 	pid = pid_from_process_handle(ProcessHandle);
 
-	LOQ_ntstatus("process", "ppBhs",
-		"ProcessHandle", ProcessHandle,
-		"BaseAddress", BaseAddress,
-		"Buffer", NumberOfBytesWritten, Buffer,
-		"BufferLength", is_valid_address_range((ULONG_PTR)NumberOfBytesWritten, 4) ? *NumberOfBytesWritten : 0,
-		"StackPivoted", is_stack_pivoted() ? "yes" : "no");
+	if (pid != GetCurrentProcess()) {
+		LOQ_ntstatus(
+			"process", "pipBhs",
+			"ProcessHandle", ProcessHandle,
+			"ProcessId", pid,
+			"BaseAddress", BaseAddress,
+			"Buffer", NumberOfBytesWritten, Buffer,
+			"BufferLength", is_valid_address_range((ULONG_PTR)NumberOfBytesWritten, 4) ? *NumberOfBytesWritten : 0,
+			"StackPivoted", is_stack_pivoted() ? "yes" : "no"
+		);
+	}
+	else {
+		LOQ_ntstatus(
+			"process", "pipBhs",
+			"ProcessHandle", ProcessHandle,
+			"BaseAddress", BaseAddress,
+			"Buffer", NumberOfBytesWritten, Buffer,
+			"BufferLength", is_valid_address_range((ULONG_PTR)NumberOfBytesWritten, 4) ? *NumberOfBytesWritten : 0,
+			"StackPivoted", is_stack_pivoted() ? "yes" : "no"
+		);
+	}
 
 	if (pid != GetCurrentProcessId() && NT_SUCCESS(ret)) {
 		if (g_config.injection)
@@ -970,8 +1024,27 @@ HOOKDEF(BOOL, WINAPI, WriteProcessMemory,
 
 	pid = pid_from_process_handle(hProcess);
 
-	LOQ_bool("process", "ppBhs", "ProcessHandle", hProcess, "BaseAddress", lpBaseAddress,
-		"Buffer", lpNumberOfBytesWritten, lpBuffer, "BufferLength", *lpNumberOfBytesWritten, "StackPivoted", is_stack_pivoted() ? "yes" : "no");
+	if (pid != GetCurrentProcess()) {
+		LOQ_bool(
+			"process", "pipBhs",
+			"ProcessHandle", hProcess,
+			"ProcessId", pid,
+			"BaseAddress", lpBaseAddress,
+			"Buffer", lpNumberOfBytesWritten, lpBuffer,
+			"BufferLength", *lpNumberOfBytesWritten,
+			"StackPivoted", is_stack_pivoted() ? "yes" : "no"
+		);
+	}
+	else {
+		LOQ_bool(
+			"process", "ppBhs",
+			"ProcessHandle", hProcess,
+			"BaseAddress", lpBaseAddress,
+			"Buffer", lpNumberOfBytesWritten, lpBuffer,
+			"BufferLength", *lpNumberOfBytesWritten,
+			"StackPivoted", is_stack_pivoted() ? "yes" : "no"
+		);
+	}
 
 	if (pid != GetCurrentProcessId() && ret) {
 		if (g_config.injection)

--- a/hook_thread.c
+++ b/hook_thread.c
@@ -286,8 +286,8 @@ HOOKDEF(NTSTATUS, WINAPI, NtOpenThread,
 	}
 
 	if (ClientId) {
-		LOQ_ntstatus("threading", "Phiii", "ThreadHandle", ThreadHandle, "DesiredAccess", DesiredAccess,
-			"ProcessId", pid, "ThreadId", tid, "ProcessId", pid);
+		LOQ_ntstatus("threading", "Phii", "ThreadHandle", ThreadHandle, "DesiredAccess", DesiredAccess,
+			"ProcessId", pid, "ThreadId", tid);
 	} else {
 		LOQ_ntstatus("threading", "PhOi", "ThreadHandle", ThreadHandle, "DesiredAccess", DesiredAccess,
 			"ObjectAttributes", ObjectAttributes, "ProcessId", pid);
@@ -306,16 +306,83 @@ HOOKDEF(NTSTATUS, WINAPI, NtGetContextThread,
 
 	NTSTATUS ret = Old_NtGetContextThread(ThreadHandle, Context);
 	DWORD pid = pid_from_thread_handle(ThreadHandle);
-	if (Context && Context->ContextFlags & CONTEXT_CONTROL)
+	if (Context && (Context->ContextFlags & (CONTEXT_CONTROL | CONTEXT_INTEGER)) == (CONTEXT_CONTROL | CONTEXT_INTEGER))
 #ifdef _WIN64
-		LOQ_ntstatus("threading", "pppi", "ThreadHandle", ThreadHandle, "HollowedInstructionPointer",
-			Context->Rcx, "CurrentInstructionPointer", Context->Rip, "ProcessId", pid);
+		LOQ_ntstatus(
+			"threading", "pppppppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Rip,
+			"Rax", Context->Rax,
+			"Rbx", Context->Rbx,
+			"Rcx", Context->Rcx,
+			"Rdx", Context->Rdx,
+			"Rsp", Context->Rsp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
 #else
-		LOQ_ntstatus("threading", "pppi", "ThreadHandle", ThreadHandle, "HollowedInstructionPointer",
-			Context->Eax, "CurrentInstructionPointer", Context->Eip, "ProcessId", pid);
+		LOQ_ntstatus(
+			"threading", "pppppppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Eip,
+			"Eax", Context->Eax,
+			"Ebx", Context->Ebx,
+			"Ecx", Context->Ecx,
+			"Edx", Context->Edx,
+			"Esp", Context->Esp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
 #endif
-	else
-		LOQ_ntstatus("threading", "pi", "ThreadHandle", ThreadHandle, "ProcessId", pid);
+	else if (Context && (Context->ContextFlags & CONTEXT_INTEGER)) {
+#ifdef _WIN64
+		LOQ_ntstatus(
+			"threading", "pppppii",
+			"ThreadHandle", ThreadHandle,
+			"Rax", Context->Rax,
+			"Rbx", Context->Rbx,
+			"Rcx", Context->Rcx,
+			"Rdx", Context->Rdx,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#else
+		LOQ_ntstatus(
+			"threading", "pppppii",
+			"ThreadHandle", ThreadHandle,
+			"Eax", Context->Eax,
+			"Ebx", Context->Ebx,
+			"Ecx", Context->Ecx,
+			"Edx", Context->Edx,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#endif
+	}
+	else if (Context && (Context->ContextFlags & CONTEXT_CONTROL)) {
+#ifdef _WIN64
+		LOQ_ntstatus(
+			"threading", "pppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Rip,
+			"Rsp", Context->Rsp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#else
+		LOQ_ntstatus(
+			"threading", "pppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Eip,
+			"Esp", Context->Esp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#endif
+	}
+	else {
+		LOQ_ntstatus("threading", "pii", "ThreadHandle", ThreadHandle, "ProcessId", pid, "ThreadId", tid);
+	}
 
 	GetThreadContextHandler(pid, Context);
 
@@ -370,14 +437,83 @@ HOOKDEF(NTSTATUS, WINAPI, NtSetContextThread,
 
 	ret = Old_NtSetContextThread(ThreadHandle, Context);
 
-	if (Context && Context->ContextFlags & CONTEXT_CONTROL)
+	if (Context && (Context->ContextFlags & (CONTEXT_CONTROL | CONTEXT_INTEGER)) == (CONTEXT_CONTROL | CONTEXT_INTEGER))
 #ifdef _WIN64
-		LOQ_ntstatus("threading", "pppp", "ThreadHandle", ThreadHandle, "HollowedInstructionPointer", Context->Rcx, "CurrentInstructionPointer", Context->Rip, "Flags", Context->ContextFlags);
+		LOQ_ntstatus(
+			"threading", "pppppppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Rip,
+			"Rax", Context->Rax,
+			"Rbx", Context->Rbx,
+			"Rcx", Context->Rcx,
+			"Rdx", Context->Rdx,
+			"Rsp", Context->Rsp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
 #else
-		LOQ_ntstatus("threading", "pppp", "ThreadHandle", ThreadHandle, "HollowedInstructionPointer", Context->Eax, "CurrentInstructionPointer", Context->Eip, "Flags", Context->ContextFlags);
+		LOQ_ntstatus(
+			"threading", "pppppppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Eip,
+			"Eax", Context->Eax,
+			"Ebx", Context->Ebx,
+			"Ecx", Context->Ecx,
+			"Edx", Context->Edx,
+			"Esp", Context->Esp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
 #endif
-	else
-		LOQ_ntstatus("threading", "p", "ThreadHandle", ThreadHandle);
+	else if (Context && (Context->ContextFlags & CONTEXT_INTEGER)) {
+#ifdef _WIN64
+		LOQ_ntstatus(
+			"threading", "pppppii",
+			"ThreadHandle", ThreadHandle,
+			"Rax", Context->Rax,
+			"Rbx", Context->Rbx,
+			"Rcx", Context->Rcx,
+			"Rdx", Context->Rdx,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#else
+		LOQ_ntstatus(
+			"threading", "pppppii",
+			"ThreadHandle", ThreadHandle,
+			"Eax", Context->Eax,
+			"Ebx", Context->Ebx,
+			"Ecx", Context->Ecx,
+			"Edx", Context->Edx,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#endif
+	}
+	else if (Context && (Context->ContextFlags & CONTEXT_CONTROL)) {
+#ifdef _WIN64
+		LOQ_ntstatus(
+			"threading", "pppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Rip,
+			"Rsp", Context->Rsp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#else
+		LOQ_ntstatus(
+			"threading", "pppii",
+			"ThreadHandle", ThreadHandle,
+			"InstructionPointer", Context->Eip,
+			"Esp", Context->Esp,
+			"ProcessId", pid,
+			"ThreadId", tid
+		);
+#endif
+	}
+	else {
+		LOQ_ntstatus("threading", "pii", "ThreadHandle", ThreadHandle, "ProcessId", pid, "ThreadId", tid);
+	}
 
 	SetThreadContextHandler(pid, Context);
 	if (pid != GetCurrentProcessId())


### PR DESCRIPTION
- Log Process ID in NtReadVirtualMemory/NtWriteVirtualMemory/ReadProcessMemory/WriteProcessMemory if the process handle used does not represent the current running process
- Remove a dupe arg from NtOpenThread
- Better logging for NtGetContextThread; logs have appropriate arguments based on the context flags
- Cloned this logic to NtSetContextThread as well
- Added PID/TID to NtGet/SetContextThread

Changes inspired by trying to detect https://research.checkpoint.com/2025/waiting-thread-hijacking/

I've found it's quite difficult to keep track of all all of the handles being mapped to various identifiers (PID/TID) from the various APIs in a signature without these improvements.