### PR TITLE
Filtering Processes Before Injection

### DIFF
--- a/CAPE/Injection.c
+++ b/CAPE/Injection.c
@@ -31,7 +31,7 @@ along with this program.If not, see <http://www.gnu.org/licenses/>.
 #include "Shlwapi.h"
 
 #pragma comment(lib, "shlwapi.lib")
-#pragma warning(push )
+#pragma warning(push)
 #pragma warning(disable : 4996)
 
 extern _NtMapViewOfSection pNtMapViewOfSection;
@@ -46,6 +46,37 @@ extern char *our_process_name;
 extern void hook_disable();
 extern void hook_enable();
 
+BOOL is_system_process(DWORD ProcessId)
+{
+    char processName[MAX_PATH] = {0};
+	HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ProcessId);
+	if (hProcess) {
+		char processPath[MAX_PATH];
+		if (GetProcessImageFileName(hProcess, processPath, MAX_PATH)) {
+			char *fileName = strrchr(processPath, '\\');
+			if (fileName) {
+				strncpy(processName, fileName + 1, MAX_PATH - 1);
+			}
+		}
+		CloseHandle(hProcess);
+	}
+
+	// Process name filtering - exclude system processes
+	const char *systemProcesses[] = {
+		"services.exe", "svchost.exe", "WmiPrvSE.exe", "wininit.exe", 
+		"winlogon.exe", "lsass.exe", "csrss.exe", "smss.exe",
+		"explorer.exe", "dwm.exe", "conhost.exe", "audiodg.exe"
+	};
+	
+	for (int i = 0; i < sizeof(systemProcesses) / sizeof(systemProcesses[0]); i++) {
+		if (!_stricmp(processName, systemProcesses[i])) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
 //**************************************************************************************
 PINJECTIONINFO GetInjectionInfo(DWORD ProcessId)
 //**************************************************************************************
@@ -53,6 +84,7 @@ PINJECTIONINFO GetInjectionInfo(DWORD ProcessId)
 	DWORD CurrentProcessId;
 
 	PINJECTIONINFO CurrentInjectionInfo = InjectionInfoList;
+
 	while (CurrentInjectionInfo)
 	{
 		CurrentProcessId = CurrentInjectionInfo->ProcessId;
@@ -685,6 +717,7 @@ PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid, ACCESS_MASK DesiredAcc
 
 	if (Pid == GetCurrentProcessId())
 		return NULL;
+	
 
 	CurrentInjectionInfo = GetInjectionInfo(Pid);
 
@@ -694,7 +727,6 @@ PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid, ACCESS_MASK DesiredAcc
 		if (CurrentInjectionInfo)
 		{
 			CurrentInjectionInfo->ProcessHandle = ProcessHandle;
-			CurrentInjectionInfo->DesiredAccess = DesiredAccess;
 			CurrentInjectionInfo->EntryPoint = (DWORD_PTR)NULL;
 			CurrentInjectionInfo->ImageDumped = FALSE;
 
@@ -1127,50 +1159,11 @@ void ProcessMessage(DWORD ProcessId, DWORD ThreadId)
 		DebugOutput("ProcessMessage: Skipping monitoring process %d", ProcessId);
 		return;
 	}
-
+	
 	if (g_config.single_process)
 	{
 		DebugOutput("ProcessMessage: Skipping monitoring process %d as single-process mode set.", ProcessId);
 		return;
-	}
-
-	// Add injection filtering logic here to prevent false positives
-	if (g_config.filter_system_injection) {
-		ACCESS_MASK DesiredAccess = 0;
-		
-		// Get the access flags used to open this process (reuse existing CurrentInjectionInfo)
-		if (CurrentInjectionInfo && CurrentInjectionInfo->DesiredAccess) {
-			DesiredAccess = CurrentInjectionInfo->DesiredAccess;
-		}
-		
-		// Define malicious injection access patterns
-		ACCESS_MASK MALICIOUS_FLAGS = PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION;
-		ACCESS_MASK LEGITIMATE_FLAGS = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | 
-									   SYNCHRONIZE | PROCESS_DUP_HANDLE | PROCESS_VM_READ;
-		
-		// If process was opened with only legitimate flags, don't inject
-		if (DesiredAccess && !(DesiredAccess & MALICIOUS_FLAGS)) {
-			if (DesiredAccess & LEGITIMATE_FLAGS) {
-				DebugOutput("ProcessMessage: INJECTION BLOCKED - Legitimate access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
-				return;
-			}
-		}
-		
-		// Log the access pattern for analysis
-		if (DesiredAccess) {
-			BOOL bHighRisk = (DesiredAccess & MALICIOUS_FLAGS) != 0;
-			BOOL bAllAccess = (DesiredAccess == PROCESS_ALL_ACCESS);
-			
-			if (bHighRisk || bAllAccess) {
-				DebugOutput("ProcessMessage: INJECTION ALLOWED - Malicious access pattern 0x%x for PID %d (%s)", 
-					DesiredAccess, ProcessId, bAllAccess ? "ALL_ACCESS" : "INJECTION_FLAGS");
-			} else {
-				DebugOutput("ProcessMessage: INJECTION ALLOWED - Unknown access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
-			}
-		} else {
-			// No access info available (process created, not opened)
-			DebugOutput("ProcessMessage: INJECTION ALLOWED - Process created (not opened) PID %d", ProcessId);
-		}
 	}
 
 	if (g_config.standalone)

--- a/CAPE/Injection.c
+++ b/CAPE/Injection.c
@@ -677,7 +677,7 @@ void CreateProcessHandler(LPWSTR lpApplicationName, LPWSTR lpCommandLine, LPPROC
 		DebugOutput("CreateProcessHandler: Injection info set for new process %d, ImageBase: 0x%p", CurrentInjectionInfo->ProcessId, CurrentInjectionInfo->ImageBase);
 }
 
-PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid)
+PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid, ACCESS_MASK DesiredAccess)
 {
 	struct InjectionInfo *CurrentInjectionInfo;
 	char DevicePath[MAX_PATH];
@@ -694,6 +694,7 @@ PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid)
 		if (CurrentInjectionInfo)
 		{
 			CurrentInjectionInfo->ProcessHandle = ProcessHandle;
+			CurrentInjectionInfo->DesiredAccess = DesiredAccess;
 			CurrentInjectionInfo->EntryPoint = (DWORD_PTR)NULL;
 			CurrentInjectionInfo->ImageDumped = FALSE;
 
@@ -1133,6 +1134,45 @@ void ProcessMessage(DWORD ProcessId, DWORD ThreadId)
 		return;
 	}
 
+	// Add injection filtering logic here to prevent false positives
+	if (g_config.filter_system_injection) {
+		ACCESS_MASK DesiredAccess = 0;
+		
+		// Get the access flags used to open this process (reuse existing CurrentInjectionInfo)
+		if (CurrentInjectionInfo && CurrentInjectionInfo->DesiredAccess) {
+			DesiredAccess = CurrentInjectionInfo->DesiredAccess;
+		}
+		
+		// Define malicious injection access patterns
+		ACCESS_MASK MALICIOUS_FLAGS = PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION;
+		ACCESS_MASK LEGITIMATE_FLAGS = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | 
+									   SYNCHRONIZE | PROCESS_DUP_HANDLE | PROCESS_VM_READ;
+		
+		// If process was opened with only legitimate flags, don't inject
+		if (DesiredAccess && !(DesiredAccess & MALICIOUS_FLAGS)) {
+			if (DesiredAccess & LEGITIMATE_FLAGS) {
+				DebugOutput("ProcessMessage: INJECTION BLOCKED - Legitimate access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
+				return;
+			}
+		}
+		
+		// Log the access pattern for analysis
+		if (DesiredAccess) {
+			BOOL bHighRisk = (DesiredAccess & MALICIOUS_FLAGS) != 0;
+			BOOL bAllAccess = (DesiredAccess == PROCESS_ALL_ACCESS);
+			
+			if (bHighRisk || bAllAccess) {
+				DebugOutput("ProcessMessage: INJECTION ALLOWED - Malicious access pattern 0x%x for PID %d (%s)", 
+					DesiredAccess, ProcessId, bAllAccess ? "ALL_ACCESS" : "INJECTION_FLAGS");
+			} else {
+				DebugOutput("ProcessMessage: INJECTION ALLOWED - Unknown access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
+			}
+		} else {
+			// No access info available (process created, not opened)
+			DebugOutput("ProcessMessage: INJECTION ALLOWED - Process created (not opened) PID %d", ProcessId);
+		}
+	}
+
 	if (g_config.standalone)
 	{
 		BOOL Wow64Process;
@@ -1194,7 +1234,7 @@ void ProcessMessage(DWORD ProcessId, DWORD ThreadId)
 				swprintf_s(CommandLine, MAX_PATH, L"%s inject %u %u %s", Loader, ProcessId, ThreadId, our_dll_path_w);
 			}
 #endif
-	}
+		}
 		hook_disable();
 		if (CreateProcessW(NULL, CommandLine, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &StartupInfoEx.StartupInfo, &ProcInfo))
 		{

--- a/CAPE/Injection.c
+++ b/CAPE/Injection.c
@@ -53,6 +53,7 @@ PINJECTIONINFO GetInjectionInfo(DWORD ProcessId)
 	DWORD CurrentProcessId;
 
 	PINJECTIONINFO CurrentInjectionInfo = InjectionInfoList;
+
 	while (CurrentInjectionInfo)
 	{
 		CurrentProcessId = CurrentInjectionInfo->ProcessId;
@@ -1128,49 +1129,84 @@ void ProcessMessage(DWORD ProcessId, DWORD ThreadId)
 		return;
 	}
 
+	// Injection filtering logic based on process name and desired access
+	if (g_config.filter_system_injection) {
+		// Get process name for filtering
+		char processName[MAX_PATH] = {0};
+		HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ProcessId);
+		if (hProcess) {
+			char processPath[MAX_PATH];
+			if (GetProcessImageFileName(hProcess, processPath, MAX_PATH)) {
+				char *fileName = strrchr(processPath, '\\');
+				if (fileName) {
+					strncpy(processName, fileName + 1, MAX_PATH - 1);
+				}
+			}
+			CloseHandle(hProcess);
+		}
+		
+		// Process name filtering - exclude system processes
+		const char *systemProcesses[] = {
+			"services.exe", "svchost.exe", "WmiPrvSE.exe", "wininit.exe", 
+			"winlogon.exe", "lsass.exe", "csrss.exe", "smss.exe",
+			"explorer.exe", "dwm.exe", "conhost.exe", "audiodg.exe"
+		};
+		
+		for (int i = 0; i < sizeof(systemProcesses) / sizeof(systemProcesses[0]); i++) {
+			if (!_stricmp(processName, systemProcesses[i])) {
+				DebugOutput("ProcessMessage: INJECTION BLOCKED - System process: %s (PID %d)", processName, ProcessId);
+				if (CurrentInjectionInfo) 
+					DebugOutput("ProcessMessage: processhandle: 0x%x", CurrentInjectionInfo->ProcessHandle);
+				else
+					DebugOutput("ProcessMessage: processhandle: not set for process %s (PID %d)", processName, ProcessId);
+
+				// if (CurrentInjectionInfo->DesiredAccess)
+				// 	DebugOutput("ProcessMessage: DesiredAccess: 0x%x", CurrentInjectionInfo->DesiredAccess);
+				// else
+				// 	DebugOutput("ProcessMessage: DesiredAccess: not set for process %s (PID %d)", processName, ProcessId);
+				// return;
+			}
+		}
+		
+		// // Desired access filtering
+		// if (CurrentInjectionInfo && CurrentInjectionInfo->DesiredAccess) {
+		// 	ACCESS_MASK DesiredAccess = CurrentInjectionInfo->DesiredAccess;
+			
+		// 	// Define malicious injection access patterns
+		// 	ACCESS_MASK MALICIOUS_FLAGS = PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION;
+		// 	ACCESS_MASK LEGITIMATE_FLAGS = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | 
+		// 								   SYNCHRONIZE | PROCESS_DUP_HANDLE | PROCESS_VM_READ;
+			
+		// 	// If process was opened with only legitimate flags, don't inject
+		// 	if (!(DesiredAccess & MALICIOUS_FLAGS)) {
+		// 		if (DesiredAccess & LEGITIMATE_FLAGS) {
+		// 			DebugOutput("ProcessMessage: INJECTION BLOCKED - Legitimate access pattern 0x%x for %s (PID %d)", 
+		// 				DesiredAccess, processName, ProcessId);
+		// 			return;
+		// 		}
+		// 	}
+			
+		// 	// Log the access pattern for analysis
+		// 	BOOL bHighRisk = (DesiredAccess & MALICIOUS_FLAGS) != 0;
+		// 	BOOL bAllAccess = (DesiredAccess == PROCESS_ALL_ACCESS);
+			
+		// 	if (bHighRisk || bAllAccess) {
+		// 		DebugOutput("ProcessMessage: INJECTION ALLOWED - Malicious access pattern 0x%x for %s (PID %d) (%s)", 
+		// 			DesiredAccess, processName, ProcessId, bAllAccess ? "ALL_ACCESS" : "INJECTION_FLAGS");
+		// 	} else {
+		// 		DebugOutput("ProcessMessage: INJECTION ALLOWED - Unknown access pattern 0x%x for %s (PID %d)", 
+		// 			DesiredAccess, processName, ProcessId);
+		// 	}
+		// } else {
+		// 	// No access info available (process created, not opened)
+		// 	DebugOutput("ProcessMessage: INJECTION ALLOWED - Process created (not opened) %s (PID %d)", processName, ProcessId);
+		// }
+	}
+
 	if (g_config.single_process)
 	{
 		DebugOutput("ProcessMessage: Skipping monitoring process %d as single-process mode set.", ProcessId);
 		return;
-	}
-
-	// Add injection filtering logic here to prevent false positives
-	if (g_config.filter_system_injection) {
-		ACCESS_MASK DesiredAccess = 0;
-		
-		// Get the access flags used to open this process (reuse existing CurrentInjectionInfo)
-		if (CurrentInjectionInfo && CurrentInjectionInfo->DesiredAccess) {
-			DesiredAccess = CurrentInjectionInfo->DesiredAccess;
-		}
-		
-		// Define malicious injection access patterns
-		ACCESS_MASK MALICIOUS_FLAGS = PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION;
-		ACCESS_MASK LEGITIMATE_FLAGS = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | 
-									   SYNCHRONIZE | PROCESS_DUP_HANDLE | PROCESS_VM_READ;
-		
-		// If process was opened with only legitimate flags, don't inject
-		if (DesiredAccess && !(DesiredAccess & MALICIOUS_FLAGS)) {
-			if (DesiredAccess & LEGITIMATE_FLAGS) {
-				DebugOutput("ProcessMessage: INJECTION BLOCKED - Legitimate access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
-				return;
-			}
-		}
-		
-		// Log the access pattern for analysis
-		if (DesiredAccess) {
-			BOOL bHighRisk = (DesiredAccess & MALICIOUS_FLAGS) != 0;
-			BOOL bAllAccess = (DesiredAccess == PROCESS_ALL_ACCESS);
-			
-			if (bHighRisk || bAllAccess) {
-				DebugOutput("ProcessMessage: INJECTION ALLOWED - Malicious access pattern 0x%x for PID %d (%s)", 
-					DesiredAccess, ProcessId, bAllAccess ? "ALL_ACCESS" : "INJECTION_FLAGS");
-			} else {
-				DebugOutput("ProcessMessage: INJECTION ALLOWED - Unknown access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
-			}
-		} else {
-			// No access info available (process created, not opened)
-			DebugOutput("ProcessMessage: INJECTION ALLOWED - Process created (not opened) PID %d", ProcessId);
-		}
 	}
 
 	if (g_config.standalone)

--- a/CAPE/Injection.c
+++ b/CAPE/Injection.c
@@ -53,7 +53,6 @@ PINJECTIONINFO GetInjectionInfo(DWORD ProcessId)
 	DWORD CurrentProcessId;
 
 	PINJECTIONINFO CurrentInjectionInfo = InjectionInfoList;
-
 	while (CurrentInjectionInfo)
 	{
 		CurrentProcessId = CurrentInjectionInfo->ProcessId;
@@ -1129,84 +1128,49 @@ void ProcessMessage(DWORD ProcessId, DWORD ThreadId)
 		return;
 	}
 
-	// Injection filtering logic based on process name and desired access
-	if (g_config.filter_system_injection) {
-		// Get process name for filtering
-		char processName[MAX_PATH] = {0};
-		HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ProcessId);
-		if (hProcess) {
-			char processPath[MAX_PATH];
-			if (GetProcessImageFileName(hProcess, processPath, MAX_PATH)) {
-				char *fileName = strrchr(processPath, '\\');
-				if (fileName) {
-					strncpy(processName, fileName + 1, MAX_PATH - 1);
-				}
-			}
-			CloseHandle(hProcess);
-		}
-		
-		// Process name filtering - exclude system processes
-		const char *systemProcesses[] = {
-			"services.exe", "svchost.exe", "WmiPrvSE.exe", "wininit.exe", 
-			"winlogon.exe", "lsass.exe", "csrss.exe", "smss.exe",
-			"explorer.exe", "dwm.exe", "conhost.exe", "audiodg.exe"
-		};
-		
-		for (int i = 0; i < sizeof(systemProcesses) / sizeof(systemProcesses[0]); i++) {
-			if (!_stricmp(processName, systemProcesses[i])) {
-				DebugOutput("ProcessMessage: INJECTION BLOCKED - System process: %s (PID %d)", processName, ProcessId);
-				if (CurrentInjectionInfo) 
-					DebugOutput("ProcessMessage: processhandle: 0x%x", CurrentInjectionInfo->ProcessHandle);
-				else
-					DebugOutput("ProcessMessage: processhandle: not set for process %s (PID %d)", processName, ProcessId);
-
-				// if (CurrentInjectionInfo->DesiredAccess)
-				// 	DebugOutput("ProcessMessage: DesiredAccess: 0x%x", CurrentInjectionInfo->DesiredAccess);
-				// else
-				// 	DebugOutput("ProcessMessage: DesiredAccess: not set for process %s (PID %d)", processName, ProcessId);
-				// return;
-			}
-		}
-		
-		// // Desired access filtering
-		// if (CurrentInjectionInfo && CurrentInjectionInfo->DesiredAccess) {
-		// 	ACCESS_MASK DesiredAccess = CurrentInjectionInfo->DesiredAccess;
-			
-		// 	// Define malicious injection access patterns
-		// 	ACCESS_MASK MALICIOUS_FLAGS = PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION;
-		// 	ACCESS_MASK LEGITIMATE_FLAGS = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | 
-		// 								   SYNCHRONIZE | PROCESS_DUP_HANDLE | PROCESS_VM_READ;
-			
-		// 	// If process was opened with only legitimate flags, don't inject
-		// 	if (!(DesiredAccess & MALICIOUS_FLAGS)) {
-		// 		if (DesiredAccess & LEGITIMATE_FLAGS) {
-		// 			DebugOutput("ProcessMessage: INJECTION BLOCKED - Legitimate access pattern 0x%x for %s (PID %d)", 
-		// 				DesiredAccess, processName, ProcessId);
-		// 			return;
-		// 		}
-		// 	}
-			
-		// 	// Log the access pattern for analysis
-		// 	BOOL bHighRisk = (DesiredAccess & MALICIOUS_FLAGS) != 0;
-		// 	BOOL bAllAccess = (DesiredAccess == PROCESS_ALL_ACCESS);
-			
-		// 	if (bHighRisk || bAllAccess) {
-		// 		DebugOutput("ProcessMessage: INJECTION ALLOWED - Malicious access pattern 0x%x for %s (PID %d) (%s)", 
-		// 			DesiredAccess, processName, ProcessId, bAllAccess ? "ALL_ACCESS" : "INJECTION_FLAGS");
-		// 	} else {
-		// 		DebugOutput("ProcessMessage: INJECTION ALLOWED - Unknown access pattern 0x%x for %s (PID %d)", 
-		// 			DesiredAccess, processName, ProcessId);
-		// 	}
-		// } else {
-		// 	// No access info available (process created, not opened)
-		// 	DebugOutput("ProcessMessage: INJECTION ALLOWED - Process created (not opened) %s (PID %d)", processName, ProcessId);
-		// }
-	}
-
 	if (g_config.single_process)
 	{
 		DebugOutput("ProcessMessage: Skipping monitoring process %d as single-process mode set.", ProcessId);
 		return;
+	}
+
+	// Add injection filtering logic here to prevent false positives
+	if (g_config.filter_system_injection) {
+		ACCESS_MASK DesiredAccess = 0;
+		
+		// Get the access flags used to open this process (reuse existing CurrentInjectionInfo)
+		if (CurrentInjectionInfo && CurrentInjectionInfo->DesiredAccess) {
+			DesiredAccess = CurrentInjectionInfo->DesiredAccess;
+		}
+		
+		// Define malicious injection access patterns
+		ACCESS_MASK MALICIOUS_FLAGS = PROCESS_CREATE_THREAD | PROCESS_VM_WRITE | PROCESS_VM_OPERATION;
+		ACCESS_MASK LEGITIMATE_FLAGS = PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_QUERY_INFORMATION | 
+									   SYNCHRONIZE | PROCESS_DUP_HANDLE | PROCESS_VM_READ;
+		
+		// If process was opened with only legitimate flags, don't inject
+		if (DesiredAccess && !(DesiredAccess & MALICIOUS_FLAGS)) {
+			if (DesiredAccess & LEGITIMATE_FLAGS) {
+				DebugOutput("ProcessMessage: INJECTION BLOCKED - Legitimate access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
+				return;
+			}
+		}
+		
+		// Log the access pattern for analysis
+		if (DesiredAccess) {
+			BOOL bHighRisk = (DesiredAccess & MALICIOUS_FLAGS) != 0;
+			BOOL bAllAccess = (DesiredAccess == PROCESS_ALL_ACCESS);
+			
+			if (bHighRisk || bAllAccess) {
+				DebugOutput("ProcessMessage: INJECTION ALLOWED - Malicious access pattern 0x%x for PID %d (%s)", 
+					DesiredAccess, ProcessId, bAllAccess ? "ALL_ACCESS" : "INJECTION_FLAGS");
+			} else {
+				DebugOutput("ProcessMessage: INJECTION ALLOWED - Unknown access pattern 0x%x for PID %d", DesiredAccess, ProcessId);
+			}
+		} else {
+			// No access info available (process created, not opened)
+			DebugOutput("ProcessMessage: INJECTION ALLOWED - Process created (not opened) PID %d", ProcessId);
+		}
 	}
 
 	if (g_config.standalone)

--- a/CAPE/Injection.h
+++ b/CAPE/Injection.h
@@ -45,7 +45,6 @@ typedef struct InjectionInfo
 {
 	DWORD			ProcessId;
 	HANDLE			ProcessHandle;
-	ACCESS_MASK		DesiredAccess;
 	DWORD			InitialThreadId;
 	DWORD_PTR		ImageBase;
 	DWORD_PTR		EntryPoint;
@@ -73,3 +72,4 @@ void MapSectionViewHandler(HANDLE ProcessHandle, HANDLE SectionHandle, PVOID Bas
 void UnmapSectionViewHandler(PVOID BaseAddress);
 void WriteMemoryHandler(HANDLE ProcessHandle, LPVOID BaseAddress, LPCVOID Buffer, SIZE_T NumberOfBytesWritten);
 void TerminateHandler();
+BOOL is_system_process(DWORD ProcessId);

--- a/CAPE/Injection.h
+++ b/CAPE/Injection.h
@@ -45,6 +45,7 @@ typedef struct InjectionInfo
 {
 	DWORD			ProcessId;
 	HANDLE			ProcessHandle;
+	ACCESS_MASK		DesiredAccess;
 	DWORD			InitialThreadId;
 	DWORD_PTR		ImageBase;
 	DWORD_PTR		EntryPoint;
@@ -54,7 +55,6 @@ typedef struct InjectionInfo
 	unsigned int	BufferSizeOfImage;
 	HANDLE			SectionHandle;
 	BOOL			DontMonitor;
-	ACCESS_MASK		DesiredAccess;
 //	struct InjectionSectionView *SectionViewList;
 	struct InjectionInfo *NextInjectionInfo;
 } INJECTIONINFO, *PINJECTIONINFO;

--- a/CAPE/Injection.h
+++ b/CAPE/Injection.h
@@ -45,6 +45,7 @@ typedef struct InjectionInfo
 {
 	DWORD			ProcessId;
 	HANDLE			ProcessHandle;
+	ACCESS_MASK		DesiredAccess;
 	DWORD			InitialThreadId;
 	DWORD_PTR		ImageBase;
 	DWORD_PTR		EntryPoint;
@@ -66,7 +67,7 @@ PINJECTIONINFO GetInjectionInfoFromHandle(HANDLE ProcessHandle);
 PINJECTIONINFO CreateInjectionInfo(DWORD ProcessId);
 BOOL DropInjectionInfo(HANDLE ProcessHandle);
 void CreateProcessHandler(LPWSTR lpApplicationName, LPWSTR lpCommandLine, LPPROCESS_INFORMATION lpProcessInformation);
-PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid);
+PCHAR OpenProcessHandler(HANDLE ProcessHandle, DWORD Pid, ACCESS_MASK DesiredAccess);
 void ResumeProcessHandler(HANDLE ProcessHandle, DWORD Pid);
 void MapSectionViewHandler(HANDLE ProcessHandle, HANDLE SectionHandle, PVOID BaseAddress, SIZE_T ViewSize);
 void UnmapSectionViewHandler(PVOID BaseAddress);

--- a/CAPE/Injection.h
+++ b/CAPE/Injection.h
@@ -45,7 +45,6 @@ typedef struct InjectionInfo
 {
 	DWORD			ProcessId;
 	HANDLE			ProcessHandle;
-	ACCESS_MASK		DesiredAccess;
 	DWORD			InitialThreadId;
 	DWORD_PTR		ImageBase;
 	DWORD_PTR		EntryPoint;
@@ -55,6 +54,7 @@ typedef struct InjectionInfo
 	unsigned int	BufferSizeOfImage;
 	HANDLE			SectionHandle;
 	BOOL			DontMonitor;
+	ACCESS_MASK		DesiredAccess;
 //	struct InjectionSectionView *SectionViewList;
 	struct InjectionInfo *NextInjectionInfo;
 } INJECTIONINFO, *PINJECTIONINFO;

--- a/config.c
+++ b/config.c
@@ -1254,10 +1254,10 @@ void parse_config_line(char* line)
 			if (g_config.injection)
 				DebugOutput("Capture of injected payloads enabled.\n");
 		}
-		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process access rights to reduce false positives
+		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process names and access patterns
 			g_config.filter_system_injection = value[0] == '1';
 			if (g_config.filter_system_injection)
-				DebugOutput("System injection filtering enabled - will filter based on process access rights.\n");
+				DebugOutput("System injection filtering enabled.\n");
 		}
 		else if (!stricmp(key, "dump-config-region")) {
 			g_config.dump_config_region = value[0] == '1';
@@ -1410,7 +1410,7 @@ void read_config(void)
 	g_config.dump_limit = DUMP_LIMIT;
 	g_config.dropped_limit = 0;
 	g_config.injection = 1;
-	g_config.filter_system_injection = 1;  // Enable by default to prevent false positives
+	g_config.filter_system_injection = 1;
 	g_config.unpacker = 1;
 	g_config.api_cap = 5000;
 	g_config.api_rate_cap = 1;

--- a/config.c
+++ b/config.c
@@ -1254,10 +1254,10 @@ void parse_config_line(char* line)
 			if (g_config.injection)
 				DebugOutput("Capture of injected payloads enabled.\n");
 		}
-		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process access rights to reduce false positives
+		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process names and access patterns
 			g_config.filter_system_injection = value[0] == '1';
 			if (g_config.filter_system_injection)
-				DebugOutput("System injection filtering enabled - will filter based on process access rights.\n");
+				DebugOutput("System injection filtering enabled.\n");
 		}
 		else if (!stricmp(key, "dump-config-region")) {
 			g_config.dump_config_region = value[0] == '1';
@@ -1410,7 +1410,10 @@ void read_config(void)
 	g_config.dump_limit = DUMP_LIMIT;
 	g_config.dropped_limit = 0;
 	g_config.injection = 1;
-	g_config.filter_system_injection = 1;  // Enable by default to prevent false positives
+	
+	g_config.filter_system_injection = 1;
+	g_config.filter_system_safe_process_pid = 0;
+	
 	g_config.unpacker = 1;
 	g_config.api_cap = 5000;
 	g_config.api_rate_cap = 1;

--- a/config.c
+++ b/config.c
@@ -1249,10 +1249,15 @@ void parse_config_line(char* line)
 			else if (g_config.unpacker == 2)
 				DebugOutput("Active unpacking of payloads enabled\n");
 		}
-		else if (!stricmp(key, "injection")) { //When set to 1 this will enable CAPE’s capture of injected payloads between processes
+		else if (!stricmp(key, "injection")) { //When set to 1 this will enable CAPEï¿½s capture of injected payloads between processes
 			g_config.injection = value[0] == '1';
 			if (g_config.injection)
 				DebugOutput("Capture of injected payloads enabled.\n");
+		}
+		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process access rights to reduce false positives
+			g_config.filter_system_injection = value[0] == '1';
+			if (g_config.filter_system_injection)
+				DebugOutput("System injection filtering enabled - will filter based on process access rights.\n");
 		}
 		else if (!stricmp(key, "dump-config-region")) {
 			g_config.dump_config_region = value[0] == '1';
@@ -1405,6 +1410,7 @@ void read_config(void)
 	g_config.dump_limit = DUMP_LIMIT;
 	g_config.dropped_limit = 0;
 	g_config.injection = 1;
+	g_config.filter_system_injection = 1;  // Enable by default to prevent false positives
 	g_config.unpacker = 1;
 	g_config.api_cap = 5000;
 	g_config.api_rate_cap = 1;

--- a/config.c
+++ b/config.c
@@ -1254,10 +1254,10 @@ void parse_config_line(char* line)
 			if (g_config.injection)
 				DebugOutput("Capture of injected payloads enabled.\n");
 		}
-		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process names and access patterns
+		else if (!stricmp(key, "filter-system-injection")) { //When set to 1 this will enable filtering of system injection based on process access rights to reduce false positives
 			g_config.filter_system_injection = value[0] == '1';
 			if (g_config.filter_system_injection)
-				DebugOutput("System injection filtering enabled.\n");
+				DebugOutput("System injection filtering enabled - will filter based on process access rights.\n");
 		}
 		else if (!stricmp(key, "dump-config-region")) {
 			g_config.dump_config_region = value[0] == '1';
@@ -1410,7 +1410,7 @@ void read_config(void)
 	g_config.dump_limit = DUMP_LIMIT;
 	g_config.dropped_limit = 0;
 	g_config.injection = 1;
-	g_config.filter_system_injection = 1;
+	g_config.filter_system_injection = 1;  // Enable by default to prevent false positives
 	g_config.unpacker = 1;
 	g_config.api_cap = 5000;
 	g_config.api_rate_cap = 1;

--- a/config.h
+++ b/config.h
@@ -168,9 +168,9 @@ struct _g_config {
 	int unpacker;
 	int injection;
 
-	// filter system injection based on process access rights
 	int filter_system_injection;
-
+	int filter_system_safe_process_pid;
+	
 	// should we dump each process on exit/analysis timeout?
 	int procdump;
 	int procmemdump;

--- a/config.h
+++ b/config.h
@@ -167,6 +167,8 @@ struct _g_config {
 	// behavioural payload extraction options
 	int unpacker;
 	int injection;
+
+	// filter system injection based on process access rights
 	int filter_system_injection;
 
 	// should we dump each process on exit/analysis timeout?

--- a/config.h
+++ b/config.h
@@ -168,6 +168,9 @@ struct _g_config {
 	int unpacker;
 	int injection;
 
+	// filter system injection based on process access rights
+	int filter_system_injection;
+
 	// should we dump each process on exit/analysis timeout?
 	int procdump;
 	int procmemdump;

--- a/config.h
+++ b/config.h
@@ -167,8 +167,6 @@ struct _g_config {
 	// behavioural payload extraction options
 	int unpacker;
 	int injection;
-
-	// filter system injection based on process access rights
 	int filter_system_injection;
 
 	// should we dump each process on exit/analysis timeout?

--- a/hook_process.c
+++ b/hook_process.c
@@ -520,7 +520,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtOpenProcess,
 	ret = Old_NtOpenProcess(ProcessHandle, DesiredAccess, ObjectAttributes, ClientId);
 
 	if (NT_SUCCESS(ret) && g_config.injection)
-		ProcessName = OpenProcessHandler(*ProcessHandle, pid);
+		ProcessName = OpenProcessHandler(*ProcessHandle, pid, DesiredAccess);
 
 	if (ProcessName)
 		LOQ_ntstatus("process", "Phis", "ProcessHandle", ProcessHandle, "DesiredAccess", DesiredAccess, "ProcessIdentifier", pid, "ProcessName", ProcessName);

--- a/hook_process.c
+++ b/hook_process.c
@@ -518,9 +518,18 @@ HOOKDEF(NTSTATUS, WINAPI, NtOpenProcess,
 	}
 
 	ret = Old_NtOpenProcess(ProcessHandle, DesiredAccess, ObjectAttributes, ClientId);
+	
+	
+	if (g_config.filter_system_injection) {
+		ACCESS_MASK legitimate_flags = PROCESS_QUERY_INFORMATION | 
+		PROCESS_QUERY_LIMITED_INFORMATION |
+		PROCESS_VM_READ | PROCESS_DUP_HANDLE |
+		SYNCHRONIZE;
 
-	if (is_system_process(pid)) 
-		g_config.filter_system_safe_process_pid = pid;
+		if ((DesiredAccess & ~legitimate_flags) == 0 && is_system_process(pid)) {
+			g_config.filter_system_safe_process_pid = pid;
+		}
+	}
 
 
 	if (NT_SUCCESS(ret) && g_config.injection)

--- a/hook_process.c
+++ b/hook_process.c
@@ -519,13 +519,19 @@ HOOKDEF(NTSTATUS, WINAPI, NtOpenProcess,
 
 	ret = Old_NtOpenProcess(ProcessHandle, DesiredAccess, ObjectAttributes, ClientId);
 
+	if (is_system_process(pid)) 
+		g_config.filter_system_safe_process_pid = pid;
+
+
 	if (NT_SUCCESS(ret) && g_config.injection)
 		ProcessName = OpenProcessHandler(*ProcessHandle, pid, DesiredAccess);
 
 	if (ProcessName)
 		LOQ_ntstatus("process", "Phis", "ProcessHandle", ProcessHandle, "DesiredAccess", DesiredAccess, "ProcessIdentifier", pid, "ProcessName", ProcessName);
+	
 	else
 		LOQ_ntstatus("process", "Phi", "ProcessHandle", ProcessHandle, "DesiredAccess", DesiredAccess, "ProcessIdentifier", pid);
+	
 
 	return ret;
 }

--- a/hook_window.c
+++ b/hook_window.c
@@ -29,7 +29,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 extern void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
 extern void ProcessMessage(DWORD ProcessId, DWORD ThreadId);
 extern void DumpSectionViewsForPid(DWORD Pid);
-extern BOOL is_system_process(DWORD ProcessId);
 
 typedef DWORD (WINAPI * __GetWindowThreadProcessId)(
 	__in HWND hWnd,
@@ -209,7 +208,7 @@ HOOKDEF(BOOL, WINAPI, PostThreadMessageA,
 		DumpSectionViewsForPid(pid);
 		// ProcessMessage(pid, 0);
 	}
-	if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+	if (g_config.filter_system_injection && pid == g_config.filter_system_safe_process_pid) {
 		return FALSE;
 	}
 	ProcessMessage(pid, 0);
@@ -234,7 +233,7 @@ HOOKDEF(BOOL, WINAPI, PostThreadMessageW,
 		DumpSectionViewsForPid(pid);
 		// ProcessMessage(pid, 0);
 	}
-	if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+	if (g_config.filter_system_injection && pid == g_config.filter_system_safe_process_pid) {
 		return FALSE;
 	}
 	ProcessMessage(pid, 0);
@@ -289,7 +288,7 @@ HOOKDEF(BOOL, WINAPI, SendNotifyMessageA,
 			DumpSectionViewsForPid(pid);
 			//ProcessMessage(pid, 0);
 		}
-		if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+		if (g_config.filter_system_injection && pid == g_config.filter_system_safe_process_pid) {
 			return FALSE;
 		}
 		ProcessMessage(pid, 0);
@@ -320,7 +319,7 @@ HOOKDEF(BOOL, WINAPI, SendNotifyMessageW,
 			DumpSectionViewsForPid(pid);
 			// ProcessMessage(pid, 0);
 		}
-		if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+		if (g_config.filter_system_injection && pid == g_config.filter_system_safe_process_pid) {
 			return FALSE;
 		}
 		ProcessMessage(pid, 0);

--- a/hook_window.c
+++ b/hook_window.c
@@ -23,10 +23,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "pipe.h"
 #include "log.h"
 
+
 #define StringAtomSize 0x100
 
+extern void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
 extern void ProcessMessage(DWORD ProcessId, DWORD ThreadId);
 extern void DumpSectionViewsForPid(DWORD Pid);
+extern BOOL is_system_process(DWORD ProcessId);
 
 typedef DWORD (WINAPI * __GetWindowThreadProcessId)(
 	__in HWND hWnd,
@@ -189,6 +192,7 @@ HOOKDEF(BOOL, WINAPI, PostMessageW,
 	return ret;
 }
 
+
 HOOKDEF(BOOL, WINAPI, PostThreadMessageA,
 	_In_  DWORD idThread,
 	_In_  UINT Msg,
@@ -198,16 +202,21 @@ HOOKDEF(BOOL, WINAPI, PostThreadMessageA,
 	BOOL ret = Old_PostThreadMessageA(idThread, Msg, wParam, lParam);
 
 	DWORD pid = GetThreadProcessId(idThread);
+	
+	LOQ_bool("windows", "iii", "ProcessId", pid, "ThreadId", idThread, "Message", Msg);
 
 	if (pid && pid != GetCurrentProcessId()) {
 		DumpSectionViewsForPid(pid);
-		ProcessMessage(pid, 0);
+		// ProcessMessage(pid, 0);
 	}
-
-	LOQ_bool("windows", "iii", "ProcessId", pid, "ThreadId", idThread, "Message", Msg);
+	if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+		return FALSE;
+	}
+	ProcessMessage(pid, 0);
 
 	return ret;
 }
+
 
 HOOKDEF(BOOL, WINAPI, PostThreadMessageW,
 	_In_  DWORD idThread,
@@ -218,13 +227,17 @@ HOOKDEF(BOOL, WINAPI, PostThreadMessageW,
 	BOOL ret = Old_PostThreadMessageW(idThread, Msg, wParam, lParam);
 
 	DWORD pid = GetThreadProcessId(idThread);
+	LOQ_bool("windows", "iii", "ProcessId", pid, "ThreadId", idThread, "Message", Msg);
+
 
 	if (pid && pid != GetCurrentProcessId()) {
 		DumpSectionViewsForPid(pid);
-		ProcessMessage(pid, 0);
+		// ProcessMessage(pid, 0);
 	}
-
-	LOQ_bool("windows", "iii", "ProcessId", pid, "ThreadId", idThread, "Message", Msg);
+	if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+		return FALSE;
+	}
+	ProcessMessage(pid, 0);
 
 	return ret;
 }
@@ -274,8 +287,12 @@ HOOKDEF(BOOL, WINAPI, SendNotifyMessageA,
 		our_GetWindowThreadProcessId(hWnd, &pid);
 		if (pid != GetCurrentProcessId()) {
 			DumpSectionViewsForPid(pid);
-			ProcessMessage(pid, 0);
+			//ProcessMessage(pid, 0);
 		}
+		if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+			return FALSE;
+		}
+		ProcessMessage(pid, 0);
 	}
 	set_lasterrors(&lasterror);
 
@@ -301,8 +318,12 @@ HOOKDEF(BOOL, WINAPI, SendNotifyMessageW,
 		our_GetWindowThreadProcessId(hWnd, &pid);
 		if (pid != GetCurrentProcessId()) {
 			DumpSectionViewsForPid(pid);
-			ProcessMessage(pid, 0);
+			// ProcessMessage(pid, 0);
 		}
+		if (g_config.filter_system_injection && is_system_process(pid) && pid == g_config.filter_system_safe_process_pid) {
+			return FALSE;
+		}
+		ProcessMessage(pid, 0);
 	}
 	set_lasterrors(&lasterror);
 


### PR DESCRIPTION
## Issue Description
As mentioned in the issue [#2608](https://github.com/kevoreilly/CAPEv2/issues/2608), when I tried to upload PDFs and MS Office documents, it accidentally creates or executes processes such as explorer.exe or svchost.exe, which will trigger false-positive signatures.

After tracking that issue, I found out that Winword.exe or AcroRd32.exe tried to open the explorer.exe process many times, which will eventually create an injection info for that process and send a message to the analyzer to inject the DLLs inside

![image](https://github.com/user-attachments/assets/4a320042-3ba7-48f5-a020-ce9ffdcc33b0)

As shown above, the process is opened with the desired access of `PROCESS_DUP_HANDLE`, so I have decided to make a filtering condition to avoid injecting the DLLs into these processes BASED ON PROCESS'S DESIRED ACCESS.

## Drawbacks
This approach is working with any 64-bit working processes, but fails with 32-bit processes with an error code of 193 (%1 is not a valid Win32 application.)

![image](https://github.com/user-attachments/assets/3af91d91-bf8f-4789-b138-c8df40b3a5a4)

