### PR TITLE
Improve standalone mode

### DIFF
--- a/capemon.c
+++ b/capemon.c
@@ -625,10 +625,16 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD dwReason, LPVOID lpReserved)
 		read_config();
 
 		if (g_config.standalone) {
-			CAPE_init();
-			DebugOutput("Standalone mode initialised.\n");
-			return TRUE;
-
+			// initialize these because some hooks behave badly when they are empty
+			if (!g_config.w_analyzer[0]) {
+				for (i = 0; i < ARRAYSIZE(g_config.analyzer); i++)
+					g_config.w_analyzer[i] = (wchar_t)(unsigned short)g_config.analyzer[i];
+			}
+			if (!g_config.w_results[0]) {
+				for (i = 0; i < ARRAYSIZE(g_config.results); i++)
+					g_config.w_results[i] = (wchar_t)(unsigned short)g_config.results[i];
+			}
+			DebugOutput("Running in standalone mode.\n");
 		}
 
 		// don't inject into our own binaries run out of the analyzer directory unless they're the first process (intended)

--- a/config.c
+++ b/config.c
@@ -1414,8 +1414,6 @@ void read_config(void)
 
 	StepLimit = SINGLE_STEP_LIMIT;
 
-	strcpy(g_config.results, g_config.analyzer);
-
 	memset(g_config.str, 0, MAX_PATH);
 	memset(g_config.pythonpath, 0, MAX_PATH);
 	memset(g_config.w_results, 0, sizeof(WCHAR)*MAX_PATH);
@@ -1427,6 +1425,8 @@ void read_config(void)
 	strncpy(g_config.analyzer, our_dll_path, strlen(our_dll_path));
 	PathRemoveFileSpec(g_config.analyzer); // remove filename
 	sprintf(config_fname, "%s\\%u.ini", g_config.analyzer, GetCurrentProcessId());
+
+	strcpy(g_config.results, g_config.analyzer);
 
 	fp = fopen(config_fname, "r");
 

--- a/pipe.c
+++ b/pipe.c
@@ -224,17 +224,23 @@ int pipe2(void *out, int *outlen, const char *fmt, ...)
 	va_list args;
 	int len;
 	int ret = -1;
-	va_start(args, fmt);
-	len = _pipe_sprintf(NULL, fmt, args);
-	if(len > 0) {
-		char *buf = calloc(1, len + 1);
-		_pipe_sprintf(buf, fmt, args);
-		va_end(args);
 
-		if(CallNamedPipeW(g_config.pipe_name, buf, len, out, *outlen,
-				(DWORD *) outlen, NMPWAIT_WAIT_FOREVER) != 0)
-			ret = 0;
-		free(buf);
+	if (g_config.standalone) {
+		*outlen = 0;
+	}
+	else {
+		va_start(args, fmt);
+		len = _pipe_sprintf(NULL, fmt, args);
+		if(len > 0) {
+			char *buf = calloc(1, len + 1);
+			_pipe_sprintf(buf, fmt, args);
+			va_end(args);
+
+			if(CallNamedPipeW(g_config.pipe_name, buf, len, out, *outlen,
+					(DWORD *) outlen, NMPWAIT_WAIT_FOREVER) != 0)
+				ret = 0;
+			free(buf);
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
A while ago I submitted https://github.com/kevoreilly/capemon/pull/79. When I debugged the hook issue I was having a couple days ago, I was confused because nothing was happening. I must have had additional changes back then that I didn't commit.

The changes in this MR make standalone mode more useful. Before, it bailed pretty early in initialization - there were no hooks set, no callbacks installed, and so on. The only issue with the code after the `return` was that it waited for input from CAPE via `pipe2()`. I changed the `pipe2()` function so that it won't contact CAPE in standalone mode.

Other than that, some more path shuffling was required so certain hooks don't behave weirdly. The `strcpy` call was using `g_config.analyzer` before it was initialized, so I moved it down so that `g_config.results` has the expected fallback value.

It's working quite well now and I think that this was the original intent for standalone mode - it neatly writes API logs etc. to disk. I also tested with CAPE to make sure the changes don't affect it in any way.