### PR TITLE
Use Standard `unordered_multimap`

### DIFF
--- a/CAPE/Scylla/ApiReader.cpp
+++ b/CAPE/Scylla/ApiReader.cpp
@@ -1116,7 +1116,7 @@ void ApiReader::clearAll()
 	minApiAddress = (DWORD_PTR)-1;
 	maxApiAddress = 0;
 
-	for ( stdext::hash_map<DWORD_PTR, ApiInfo *>::iterator it = apiList.begin(); it != apiList.end(); ++it )
+	for ( std::unordered_multimap<DWORD_PTR, ApiInfo *>::iterator it = apiList.begin(); it != apiList.end(); ++it )
 	{
 		delete it->second;
 	}

--- a/CAPE/Scylla/ApiReader.cpp
+++ b/CAPE/Scylla/ApiReader.cpp
@@ -12,7 +12,7 @@ extern "C" void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
 extern "C" void ErrorOutput(_In_ LPCTSTR lpOutputString, ...);
 extern "C" SIZE_T GetAllocationSize(PVOID Address);
 
-stdext::hash_multimap<DWORD_PTR, ApiInfo *> ApiReader::apiList; //api look up table
+std::unordered_multimap<DWORD_PTR, ApiInfo *> ApiReader::apiList; //api look up table
 std::map<DWORD_PTR, ImportModuleThunk> *  ApiReader::moduleThunkList; //store found apis
 
 DWORD_PTR ApiReader::minApiAddress = (DWORD_PTR)-1;
@@ -690,7 +690,7 @@ bool ApiReader::isApiAddressValid(DWORD_PTR virtualAddress)
 
 ApiInfo * ApiReader::getApiByVirtualAddress(DWORD_PTR virtualAddress, bool * isSuspect)
 {
-	stdext::hash_multimap<DWORD_PTR, ApiInfo *>::iterator it1, it2;
+	std::unordered_multimap<DWORD_PTR, ApiInfo *>::iterator it1, it2;
 	size_t c = 0;
 	size_t countDuplicates = apiList.count(virtualAddress);
 	int countHighPriority = 0;
@@ -773,7 +773,7 @@ ApiInfo * ApiReader::getApiByVirtualAddress(DWORD_PTR virtualAddress, bool * isS
 	return (ApiInfo *) 1; 
 }
 
-ApiInfo * ApiReader::getScoredApi(stdext::hash_multimap<DWORD_PTR, ApiInfo *>::iterator it1,size_t countDuplicates, bool hasName, bool hasUnicodeAnsiName, bool hasNoUnderlineInName, bool hasPrioDll,bool hasPrio0Dll,bool hasPrio1Dll, bool hasPrio2Dll, bool firstWin )
+ApiInfo * ApiReader::getScoredApi(std::unordered_multimap<DWORD_PTR, ApiInfo *>::iterator it1,size_t countDuplicates, bool hasName, bool hasUnicodeAnsiName, bool hasNoUnderlineInName, bool hasPrioDll,bool hasPrio0Dll,bool hasPrio1Dll, bool hasPrio2Dll, bool firstWin )
 {
 	ApiInfo * foundApi = 0;
 	ApiInfo * foundMatchingApi = 0;

--- a/CAPE/Scylla/ApiReader.h
+++ b/CAPE/Scylla/ApiReader.h
@@ -2,7 +2,7 @@
 
 #include <windows.h>
 #include <map>
-#include <hash_map>
+#include <unordered_map>
 #include "ProcessAccessHelp.h"
 #include "Thunks.h"
 

--- a/CAPE/Scylla/ApiReader.h
+++ b/CAPE/Scylla/ApiReader.h
@@ -70,6 +70,6 @@ private:
 	bool isApiBlacklisted( const char * functionName );
 	bool isWinSxSModule( ModuleInfo * module );
 
-	ApiInfo * getScoredApi(stdext::hash_map<DWORD_PTR, ApiInfo *>::iterator it1,size_t countDuplicates, bool hasName, bool hasUnicodeAnsiName, bool hasNoUnderlineInName, bool hasPrioDll,bool hasPrio0Dll,bool hasPrio1Dll, bool hasPrio2Dll, bool firstWin );
+	ApiInfo * getScoredApi(std::unordered_multimap<DWORD_PTR, ApiInfo *>::iterator it1,size_t countDuplicates, bool hasName, bool hasUnicodeAnsiName, bool hasNoUnderlineInName, bool hasPrioDll,bool hasPrio0Dll,bool hasPrio1Dll, bool hasPrio2Dll, bool firstWin );
 
 };

--- a/CAPE/Scylla/ApiReader.h
+++ b/CAPE/Scylla/ApiReader.h
@@ -11,7 +11,7 @@ typedef std::pair<DWORD_PTR, ApiInfo *> API_Pair;
 class ApiReader : public ProcessAccessHelp
 {
 public:
-	static stdext::hash_multimap<DWORD_PTR, ApiInfo *> apiList; //api look up table
+	static std::unordered_multimap<DWORD_PTR, ApiInfo *> apiList; //api look up table
 
 	static std::map<DWORD_PTR, ImportModuleThunk> * moduleThunkList; //store found apis
 

--- a/CAPE/Scylla/ImportsHandling.h
+++ b/CAPE/Scylla/ImportsHandling.h
@@ -2,7 +2,7 @@
 
 #include <windows.h>
 #include <map>
-#include <hash_map>
+#include <unordered_map>
 
 class ImportThunk;
 class ImportModuleThunk;

--- a/capemon.vcxproj
+++ b/capemon.vcxproj
@@ -97,7 +97,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>CUCKOODBG;WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS_DEBUG;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CUCKOODBG;WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS_DEBUG;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -122,7 +122,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>CUCKOODBG;WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS_DEBUG;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CUCKOODBG;WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS_DEBUG;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -145,7 +145,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGSNDEBUG;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGSNDEBUG;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -180,7 +180,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_WIN64;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WIN64;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;MONGO_HAVE_STDINT;MONGO_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>


### PR DESCRIPTION
I'm the primary maintainer of Microsoft's C++ Standard Library implementation. The MSVC developers regularly build popular open-source projects, including yours, with development versions of the build tools in order to find and fix regressions in the compiler and libraries before they're released to the world. This also allows us to provide advance notice of breaking changes, which is the case here.

I'm working on removing our non-Standard `<hash_map>` implementation, which has been deprecated for many years, with microsoft/STL#5764. Your project has been defining the escape hatch macro which warned that "`<hash_map>` is deprecated and will be REMOVED." Fortunately, switching your code over to use the Standard container was simple enough for me to do it (even though I know very little about your codebase) and I was even able to fix a small mistake with iterator types.

Although we're building your project with VS 2026 and your README says that you're using VS 2017, these changes will be compatible with VS 2017, and will unblock future upgrades for you.

Hope this helps!

# Commits
* Include `<unordered_map>` instead of `<hash_map>`.
* Use `std::unordered_multimap` instead of `stdext::hash_multimap`.
* Fix: Use `unordered_multimap::iterator` instead of `hash_map::iterator`.
  + In ApiReader.cpp, `ApiReader::clearAll()` is iterating through `apiList`, which is multi.
  + In ApiReader.h, `ApiReader::getScoredApi()` should be declared as taking multi to match its definition in ApiReader.cpp, as it's taking iterators into `apiList`.
  + This was compiling despite the single/multi mismatch because in MSVC's implementation, for both legacy `hash_map` and Standard `unordered_map`, the containers have the same iterator types regardless of single/multi, but it's still a conformance issue and should be fixed.
* Remove `_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS`.
