### PR TITLE
Lots of new WMI goodies

### DIFF
--- a/capemon.vcxproj
+++ b/capemon.vcxproj
@@ -247,6 +247,7 @@
     <ClCompile Include="hooking_64.c" />
     <ClCompile Include="hooks.c" />
     <ClCompile Include="hook_clr.c" />
+    <ClCompile Include="hook_com.c" />
     <ClCompile Include="hook_crypto.c" />
     <ClCompile Include="hook_file.c" />
     <ClCompile Include="hook_lang.c" />

--- a/capemon.vcxproj.filters
+++ b/capemon.vcxproj.filters
@@ -297,6 +297,9 @@
     <ClCompile Include="hook_wmi.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="hook_com.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="config.h">

--- a/config.h
+++ b/config.h
@@ -35,6 +35,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SPOOFED_CPU_CORE_NUM 4
 
+// Defines to string representation of above vars so we don't need to do useless converts
+#define WIDE_SPOOFED_RAM L"4294967296"
+#define WIDE_SPOOFED_RAM_IN_KB L"4194304"
+#define WIDE_DISK_LOGICAL_SIZE L"1098988720128" // SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE
+
 
 struct _g_config {
 	// name of the pipe to communicate with cuckoo

--- a/hook_com.c
+++ b/hook_com.c
@@ -1,0 +1,73 @@
+
+#include "hooking.h"
+#include "log.h"
+#include "CAPE\CAPE.h"
+#include <Wbemidl.h>
+
+BOOL ContainsNamespace(const wchar_t* resource, const wchar_t* target) {
+	/*
+	* Basically case insensitive strstr except we don't care about forward/backward slashes.
+	* Used for namespace checks in WbemLocator_ConnectServer
+	*/
+	if (!resource || !target) {
+		return FALSE;
+	}
+
+	// Iterate through the resource string to find a starting match point
+	for (; *resource; ++resource) {
+		const wchar_t* h = resource; // Haystack pointer
+		const wchar_t* n = target;   // Needle pointer
+
+		// Attempt to match the target string from the current position
+		while (*h && *n) {
+			BOOL isSlashMatch = (*h == L'/' || *h == L'\\') && (*n == L'/' || *n == L'\\');
+			if (isSlashMatch || (towlower(*h) == towlower(*n))) {
+				h++;
+				n++;
+			}
+			else {
+				// Break on mismatch
+				break;
+			}
+		}
+
+		// If we reached the end of the target string, it's a successful match
+		if (*n == L'\0') {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+__declspec(thread) BOOL bHookViaWbemLocator;
+HOOKDEF(HRESULT, WINAPI, WbemLocator_ConnectServer,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strNetworkResource,
+	_In_	const BSTR		strUser,
+	_In_	const BSTR		strPassword,
+	_In_	const BSTR		strLocale,
+	_In_	long			lSecurityFlags,
+	_In_	const BSTR		strAuthority,
+	_In_	IWbemContext	*pCtx,
+	_Out_	IWbemServices	**ppNamespace
+) {
+	HRESULT ret;
+	ret = Old_WbemLocator_ConnectServer(_this, strNetworkResource, strUser, strPassword, strLocale, lSecurityFlags, strAuthority, pCtx, ppNamespace);
+
+	if (ret == S_OK && (
+		ContainsNamespace(strNetworkResource, L"ROOT\\CIMV2") ||
+		ContainsNamespace(strNetworkResource, L"ROOT\\SecurityCenter2") ||
+		ContainsNamespace(strNetworkResource, L"ROOT\\Microsoft\\Windows\\Defender")
+		))
+	{
+		bHookViaWbemLocator = TRUE;
+		if (set_com_hooks(NULL, NULL, *ppNamespace) == -1) {
+			DebugOutput("Unable to set COM hook on WbemLocator_ConnectServer");
+		}
+		bHookViaWbemLocator = FALSE;
+	}
+
+	LOQ_hresult("com", "uu", "NetworkResource", strNetworkResource, "User", strUser);
+	return ret;
+}

--- a/hook_special.c
+++ b/hook_special.c
@@ -385,6 +385,8 @@ HOOKDEF(HRESULT, WINAPI, CoCreateInstance,
 	memcpy(&saved_hookinfo, hook_info(), sizeof(saved_hookinfo));
 	ret = Old_CoCreateInstance(rclsid, pUnkOuter, dwClsContext, riid, ppv);
 	memcpy(hook_info(), &saved_hookinfo, sizeof(saved_hookinfo));
+	if (ret == S_OK)
+		set_com_hooks(rclsid, riid, *ppv);
 
 	get_lasterrors(&lasterror);
 
@@ -438,6 +440,9 @@ HOOKDEF(HRESULT, WINAPI, CoCreateInstanceEx,
 
 
 	if (!called_by_hook()) {
+		if (ret == S_OK)
+			set_com_hooks(rclsid, pResults->pIID, pResults->pItf);
+
 		get_lasterrors(&lasterror);
 		pProgIDFromCLSID(&id1, &resolv);
 

--- a/hook_wmi.c
+++ b/hook_wmi.c
@@ -1,99 +1,302 @@
 #include "log.h"
 #include "misc.h"
+#include <Wbemidl.h>
+
+void SpoofWmiData(const wchar_t* szClassName, const wchar_t* wszName, VARIANT* pVal) {
+	if (g_config.no_stealth)
+		return;
+
+	if (!szClassName || !wszName || !pVal)
+		return;
+
+	//
+	// Spoofery logic for BSTR (wchar_t *)
+	//
+	if (pVal->vt == VT_BSTR) {
+		if (!_wcsicmp(pVal->bstrVal, L"Microsoft Basic Display Adapter")) {
+			SysFreeString(pVal->bstrVal);
+			pVal->bstrVal = SysAllocString(SPOOFED_GPU_NAME);
+		}
+		else if (!_wcsicmp(wszName, L"TotalPhysicalMemory")) {
+			unsigned long long actualMemory = wcstoull(pVal->bstrVal, NULL, 10);
+			if (actualMemory < SPOOFED_RAM) {
+				SysFreeString(pVal->bstrVal);
+				pVal->bstrVal = SysAllocString(WIDE_SPOOFED_RAM);
+			}
+		}
+		else if (!_wcsicmp(wszName, L"TotalVisibleMemorySize")) {
+			unsigned long long actualMemory = wcstoull(pVal->bstrVal, NULL, 10);
+			// actualMemory is in Kilobytes, our spoofed values are in bytes
+			if (actualMemory < (SPOOFED_RAM / 1024)) {
+				SysFreeString(pVal->bstrVal);
+				pVal->bstrVal = SysAllocString(WIDE_SPOOFED_RAM_IN_KB);
+			}
+		}
+		//
+		// Logic for BSTR fakery specific to an exact szClassName
+		//
+		else if (!_wcsicmp(szClassName, L"Win32_LogicalDisk") && !_wcsicmp(wszName, L"Size")) {
+			unsigned long long lSize = wcstoull(pVal->bstrVal, NULL, 10);
+			if (lSize < SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE) {
+				SysFreeString(pVal->bstrVal);
+				pVal->bstrVal = SysAllocString(WIDE_DISK_LOGICAL_SIZE);
+				//pipe("DEBUG:WMI_Get: Spoofed LogicalDisk.Size: %Z", newSize);
+			}
+		}
+		else if (!_wcsicmp(szClassName, L"Win32_PhysicalMemory") && !_wcsicmp(wszName, L"Capacity")) {
+			unsigned long long actualMemory = wcstoull(pVal->bstrVal, NULL, 10);
+			if (actualMemory < SPOOFED_RAM) {
+				SysFreeString(pVal->bstrVal);
+				pVal->bstrVal = SysAllocString(WIDE_SPOOFED_RAM);
+			}
+		}
+	}
+	//
+	// Spoofery logic for I4 (Signed 32-bit integer)
+	//
+	else if (pVal->vt == VT_I4) {
+		if (!_wcsicmp(szClassName, L"Win32_Processor") && !_wcsicmp(wszName, L"ThreadCount")) {
+			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
+				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+		}
+		else if (!_wcsicmp(wszName, L"NumberOfCores")) {
+			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
+				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+		}
+		else if (!_wcsicmp(wszName, L"NumberOfLogicalProcessors")) {
+			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
+				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+		}
+		else if (!_wcsicmp(wszName, L"NumberOfEnabledCore")) {
+			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
+				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+		}
+		else if (!_wcsicmp(wszName, L"AdapterRAM")) {
+			if (SPOOFED_GPU_RAM > 0x7FFFFFFFULL) {
+				// Mimic overflowing the I4 if you have >2GB of Spoofed GPU RAM
+				pVal->lVal = 0x7FFFFFFF;
+			}
+			else {
+				// Cast to LONG to avoid compiler warning if SPOOFED_GPU_RAM is >2GB
+				if (pVal->lVal < (LONG)SPOOFED_GPU_RAM) {
+					pVal->lVal = (LONG)SPOOFED_GPU_RAM;
+				}
+			}
+		}
+	}
+	//
+	// Spoofery logic for NULL
+	//
+	else if (pVal->vt == VT_NULL) {
+		if (!_wcsicmp(wszName, L"SMBIOSBIOSVersion")) {
+			pVal->vt = VT_BSTR;
+			pVal->bstrVal = SysAllocString(L"1.23.1");
+		}
+	}
+}
 
 HOOKDEF(HRESULT, WINAPI, WMI_Get,
-	PVOID		_this,
-	LPCWSTR		wszName,
-	LONG		lFlags,
-	VARIANT*	pVal,
-	LONG*		pType,
-	LONG*		plFlavor
+	_In_		PVOID	_this,
+	_In_		LPCWSTR	wszName,
+	_In_		LONG	lFlags,
+	_Out_		VARIANT	*pVal,
+	_Out_opt_	CIMTYPE	*pType,
+	_Out_opt_	LONG	*plFlavor
 ) {
 	HRESULT ret;
+	WCHAR szClassName[256] = L"";
+	if (wcscmp(wszName, L"__CLASS") != 0) {
+		VARIANT classVariant;
+		VariantInit(&classVariant);
+		IWbemClassObject* pWmiObject = (IWbemClassObject*)_this;
+		HRESULT hr = pWmiObject->lpVtbl->Get(pWmiObject, L"__CLASS", 0, &classVariant, NULL, NULL);
+		if (SUCCEEDED(hr) && classVariant.vt == VT_BSTR) {
+			wcscpy_s(szClassName, _countof(szClassName), classVariant.bstrVal);
+		}
+		VariantClear(&classVariant);
+	}
+
 	ret = Old_WMI_Get(_this, wszName, lFlags, pVal, pType, plFlavor);
-	LOQ_hresult("system", "un", "Name", wszName, "Value", pVal);
+	SpoofWmiData(szClassName, wszName, pVal);
+
+	// Short circuit, return early for things we don't want to log
+	if (!ret && !g_config.full_logs && wszName) {
+		if (
+			!wcscmp(wszName, L"__GENUS") ||
+			!wcscmp(wszName, L"__PATH") ||
+			!wcscmp(wszName, L"__RELPATH") ||
+			!wcscmp(wszName, L"__SUPERCLASS") ||
+			!wcscmp(wszName, L"SECURITY_DESCRIPTOR") ||
+			!wcscmp(wszName, L"__NAMESPACE") ||
+			!wcscmp(wszName, L"__CLASS") ||
+			!wcscmp(wszName, L"__DERIVATION")
+		) {
+			return ret;
+		}
+	}
+
+	LOQ_hresult("system", "unu", "Name", wszName, "Value", pVal, "Class", szClassName);
 	return ret;
 }
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecQuery,
-	PVOID		_this,
-	const BSTR	strQueryLanguage,
-	const BSTR	strQuery,
-	LONG		lFlags,
-	PVOID		pCtx,
-	PVOID*		ppEnum
+HOOKDEF(HRESULT, WINAPI, WMI_Next,
+	_In_		PVOID	_this,
+	_In_		LONG	lFlags,
+	_Out_		BSTR	*strName,
+	_Out_		VARIANT	*pVal,
+	_Out_opt_	CIMTYPE	*pType,
+	_Out_opt_	LONG	*plFlavor
 ) {
-	HRESULT ret = 0;
-	LOQ_hresult("system", "u", "Query", strQuery);
-	return 0;
+	HRESULT ret = Old_WMI_Next(_this, lFlags, strName, pVal, pType, plFlavor);
+
+	// Return early for some cases we don't want to log / spoof
+	if (ret != S_OK)
+		return ret;
+
+	if (!pVal)
+		return ret;
+
+	if (pVal->vt == VT_NULL)
+		return ret;
+
+	if (!strName || !*strName)
+		return ret;
+
+	// If all is well at this point, we should do the spoofs
+	lasterror_t lasterror;
+	get_lasterrors(&lasterror);
+	VARIANT classVariant;
+	VariantInit(&classVariant);
+
+	__try {
+		IWbemClassObject* pWmiObject = (IWbemClassObject*)_this;
+		HRESULT hr = pWmiObject->lpVtbl->Get(pWmiObject, L"__CLASS", 0, &classVariant, NULL, NULL);
+		WCHAR szClassName[256] = L"";
+		if (SUCCEEDED(hr) && classVariant.vt == VT_BSTR) {
+			wcscpy_s(szClassName, _countof(szClassName), classVariant.bstrVal);
+		}
+		SpoofWmiData(szClassName, *strName, pVal);
+		LOQ_hresult("system", "unu", "Name", *strName, "Value", pVal, "Class", szClassName);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		LOQ_hresult("system", "un", "Name", *strName, "Value", pVal);
+	}
+
+	VariantClear(&classVariant);
+	set_lasterrors(&lasterror);
+	return ret;
 }
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecQueryAsync,
-	PVOID		_this,
-	const BSTR	strQueryLanguage,
-	const BSTR	strQuery,
-	long		lFlags,
-	PVOID		pCtx,
-	PVOID		pResponseHandler
+HOOKDEF(HRESULT, WINAPI, WMI_ExecQuery,
+	_In_	PVOID					_this,
+	_In_	const BSTR				strQueryLanguage,
+	_In_	const BSTR				strQuery,
+	_In_	LONG					lFlags,
+	_In_	IWbemContext			*pCtx,
+	_Out_	IEnumWbemClassObject	**ppEnum
 ) {
 	HRESULT ret = 0;
-	LOQ_hresult("system", "u", "Query", strQuery);
-	return 0;
+	LOQ_hresult("system", "uu", "Query", strQuery, "QueryLanguage", strQueryLanguage);
+	return Old_WMI_ExecQuery(_this, strQueryLanguage, strQuery, lFlags, pCtx, ppEnum);
 }
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecMethod,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	const BSTR	strMethodName,
-	long		lFlags,
-	PVOID		pCtx,
-	PVOID		pInParams,
-	PVOID*		ppOutParams,
-	PVOID*		ppCallResult
+HOOKDEF(HRESULT, WINAPI, WMI_ExecQueryAsync,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strQueryLanguage,
+	_In_	const BSTR		strQuery,
+	_In_	LONG			lFlags,
+	_In_	IWbemContext	*pCtx,
+	_In_	IWbemObjectSink	*pResponseHandler
+) {
+	HRESULT ret = 0;
+	LOQ_hresult("system", "uu", "Query", strQuery, "QueryLanguage", strQueryLanguage);
+	return Old_WMI_ExecQueryAsync(_this, strQueryLanguage, strQuery, lFlags, pCtx, pResponseHandler);
+}
+
+HOOKDEF(HRESULT, WINAPI, WMI_ExecMethod,
+	_In_	PVOID				_this,
+	_In_	const BSTR			strObjectPath,
+	_In_	const BSTR			strMethodName,
+	_In_	LONG				lFlags,
+	_In_	IWbemContext		*pCtx,
+	_In_	IWbemClassObject	*pInParams,
+	_Out_	IWbemClassObject	**ppOutParams,
+	_Out_	IWbemCallResult		**ppCallResult
 ) {
 	HRESULT ret = 0;
 	LOQ_hresult("system", "uu", "ObjectPath", strObjectPath, "MethodName", strMethodName);
-	return 0;
+	return Old_WMI_ExecMethod(_this, strObjectPath, strMethodName, lFlags, pCtx, pInParams, ppOutParams, ppCallResult);
 }
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecMethodAsync,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	const BSTR	strMethodName,
-	long		lFlags,
-	PVOID		pCtx,
-	PVOID		pInParams,
-	PVOID		pResponseHandler
+HOOKDEF(HRESULT, WINAPI, WMI_ExecMethodAsync,
+	_In_	PVOID				_this,
+	_In_	const BSTR			strObjectPath,
+	_In_	const BSTR			strMethodName,
+	_In_	LONG				lFlags,
+	_In_	IWbemContext		*pCtx,
+	_In_	IWbemClassObject	*pInParams,
+	_In_	IWbemObjectSink		*pResponseHandler
 ) {
 	HRESULT ret = 0;
 	LOQ_hresult("system", "uu", "ObjectPath", strObjectPath, "MethodName", strMethodName);
-	return 0;
+	return Old_WMI_ExecMethodAsync(_this, strObjectPath, strMethodName, lFlags, pCtx, pInParams, pResponseHandler);
 }
 
-HOOKDEF_NOTAIL(WINAPI, WMI_GetObject,
-	PVOID           _this,
-	const BSTR      strObjectPath,
-	long            lFlags,
-	PVOID           pCtx,
-	PVOID*          ppObject,
-	PVOID*          ppCallResult
+HOOKDEF(HRESULT, WINAPI, WMI_GetObject,
+	_In_	PVOID				_this,
+	_In_	const BSTR			strObjectPath,
+	_In_	LONG				lFlags,
+	_In_	IWbemContext		*pCtx,
+	_Out_	IWbemClassObject	**ppObject,
+	_Out_	IWbemCallResult		**ppCallResult
 ) {
 	HRESULT ret = 0;
 	if (strObjectPath && SysStringLen(strObjectPath) > 0)
 		LOQ_hresult("system", "u", "ObjectPath", strObjectPath);
 	else
-		LOQ_hresult("system", "u", "ObjectPath", L"[NULL or Empty]");
-	return 0;
+		LOQ_hresult("system", "u", "ObjectPath", L"");
+
+	return Old_WMI_GetObject(_this, strObjectPath, lFlags, pCtx, ppObject, ppCallResult);
 }
 
-HOOKDEF_NOTAIL(WINAPI, WMI_GetObjectAsync,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	long		lFlags,
-	PVOID		pCtx,
-	PVOID		pResultHandler
+HOOKDEF(HRESULT, WINAPI, WMI_GetObjectAsync,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strObjectPath,
+	_In_	LONG			lFlags,
+	_In_	IWbemContext	*pCtx,
+	_In_	IWbemObjectSink	*pResultHandler
 ) {
 	HRESULT ret = 0;
-	LOQ_hresult("system", "u", "ObjectPath", strObjectPath);
-	return 0;
+	if (strObjectPath && SysStringLen(strObjectPath) > 0)
+		LOQ_hresult("system", "u", "ObjectPath", strObjectPath);
+	else
+		LOQ_hresult("system", "u", "ObjectPath", L"");
+
+	return Old_WMI_GetObjectAsync(_this, strObjectPath, lFlags, pCtx, pResultHandler);
 }
+
+/*
+HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnum,
+	_In_	PVOID					_this,
+	_In_	const BSTR				strFilter,
+	_In_	long					lFlags,
+	_In_	IWbemContext			*pCtx,
+	_Out_	IEnumWbemClassObject	**ppEnum
+) {
+	HRESULT ret = 0;
+	LOQ_hresult("system", "u", "QueryClass", strFilter);
+	return Old_WMI_CreateInstanceEnum(_this, strFilter, lFlags, pCtx, ppEnum);
+}
+
+HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnumAsync,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strFilter,
+	_In_	long			lFlags,
+	_In_	IWbemContext	*pCtx,
+	_In_	IWbemObjectSink	*pResponseHandler
+) {
+	HRESULT ret = 0;
+	LOQ_hresult("system", "u", "QueryClass", strFilter);
+	return Old_WMI_CreateInstanceEnumAsync(_this, strFilter, lFlags, pCtx, pResponseHandler);
+}
+*/

--- a/hook_wmi.c
+++ b/hook_wmi.c
@@ -12,7 +12,7 @@ void SpoofWmiData(const wchar_t* szClassName, const wchar_t* wszName, VARIANT* p
 	//
 	// Spoofery logic for BSTR (wchar_t *)
 	//
-	if (pVal->vt == VT_BSTR) {
+	if (pVal->vt == VT_BSTR && pVal->bstrVal) {
 		if (!_wcsicmp(pVal->bstrVal, L"Microsoft Basic Display Adapter")) {
 			SysFreeString(pVal->bstrVal);
 			pVal->bstrVal = SysAllocString(SPOOFED_GPU_NAME);
@@ -104,7 +104,7 @@ HOOKDEF(HRESULT, WINAPI, WMI_Get,
 ) {
 	HRESULT ret;
 	WCHAR szClassName[256] = L"";
-	if (wcscmp(wszName, L"__CLASS") != 0) {
+	if (wszName && wcscmp(wszName, L"__CLASS") != 0) {
 		VARIANT classVariant;
 		VariantInit(&classVariant);
 		IWbemClassObject* pWmiObject = (IWbemClassObject*)_this;

--- a/hook_wmi.c
+++ b/hook_wmi.c
@@ -274,7 +274,6 @@ HOOKDEF(HRESULT, WINAPI, WMI_GetObjectAsync,
 	return Old_WMI_GetObjectAsync(_this, strObjectPath, lFlags, pCtx, pResultHandler);
 }
 
-/*
 HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnum,
 	_In_	PVOID					_this,
 	_In_	const BSTR				strFilter,
@@ -298,4 +297,3 @@ HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnumAsync,
 	LOQ_hresult("system", "u", "QueryClass", strFilter);
 	return Old_WMI_CreateInstanceEnumAsync(_this, strFilter, lFlags, pCtx, pResponseHandler);
 }
-*/

--- a/hook_wmi.c
+++ b/hook_wmi.c
@@ -40,7 +40,6 @@ void SpoofWmiData(const wchar_t* szClassName, const wchar_t* wszName, VARIANT* p
 			if (lSize < SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE) {
 				SysFreeString(pVal->bstrVal);
 				pVal->bstrVal = SysAllocString(WIDE_DISK_LOGICAL_SIZE);
-				//pipe("DEBUG:WMI_Get: Spoofed LogicalDisk.Size: %Z", newSize);
 			}
 		}
 		else if (!_wcsicmp(szClassName, L"Win32_PhysicalMemory") && !_wcsicmp(wszName, L"Capacity")) {

--- a/hooking.h
+++ b/hooking.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
 Cuckoo Sandbox - Automated Malware Analysis
 Copyright (C) 2010-2015 Cuckoo Sandbox Developers, Optiv, Inc. (brad.spengler@optiv.com)
@@ -309,3 +310,11 @@ static inline BOOLEAN disable_this_hook(hook_t *h)
 void hook_init();
 
 #endif
+
+int set_com_hooks(REFCLSID	rclsid, REFIID riid, PVOID pComObject);
+
+typedef struct _com_hook_t {
+	hook_t			hook;
+	REFCLSID		rclsid;
+	REFIID			riid;
+} com_hook_t;

--- a/hooks.c
+++ b/hooks.c
@@ -71,6 +71,25 @@ void disable_tail_call_optimization(void)
 #define HOOK_EXERVA(funcname, timestamp, rva) {NULL, #funcname, NULL, NULL, \
 	&New_##funcname, (void **) &Old_##funcname, NULL, FALSE, FALSE, 0, FALSE, timestamp, rva}
 
+#define HOOK_COM(moniker) {NULL, #moniker, NULL, NULL, \
+    &New_##moniker, (void **) &Old_##moniker, NULL, FALSE, FALSE, 0, FALSE, 0, FALSE}
+
+#define HOOK_COM_WITHNAME(friendlyname, funcname) {NULL, #funcname, NULL, NULL, \
+    &New_##friendlyname, (void **) &Old_##friendlyname, NULL, FALSE, FALSE, 0, FALSE, 0, FALSE}
+
+
+com_hook_t g_com_hooks[] = {
+	{ HOOK_COM(WbemLocator_ConnectServer), &CLSID_WbemLocator, &IID_IWbemLocator },
+	{ HOOK_COM_WITHNAME(WMI_ExecQuery, IWbemServices_ExecQuery), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_ExecQueryAsync, IWbemServices_ExecQueryAsync), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_CreateInstanceEnum, IWbemServices_CreateInstanceEnum), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_CreateInstanceEnumAsync, IWbemServices_CreateInstanceEnumAsync), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_GetObject, IWbemServices_GetObjectW), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_GetObjectAsync, IWbemServices_GetObjectAsync), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_ExecMethod, IWbemServices_ExecMethod), NULL, NULL },
+	{ HOOK_COM_WITHNAME(WMI_ExecMethodAsync, IWbemServices_ExecMethodAsync), NULL, NULL },
+};
+
 hook_t full_hooks[] = {
 	// Process Hooks
 	HOOK_NOTAIL_ALT(ntdll, RtlDispatchException, 2),
@@ -187,15 +206,6 @@ hook_t full_hooks[] = {
 	HOOK_WITHNAME(fastprox, WMI_Get, "?Get@CWbemObject@@UAGJPBGJPAUtagVARIANT@@PAJ2@Z"),
 	HOOK_WITHNAME(fastprox, WMI_Next, "?Next@CWbemObject@@UAGJJPAPAGPAUtagVARIANT@@PAJ2@Z"),
 #endif
-	HOOK(fastprox, WMI_ExecQuery),
-	HOOK(fastprox, WMI_ExecQueryAsync),
-	HOOK(fastprox, WMI_ExecMethod),
-	HOOK(fastprox, WMI_ExecMethodAsync),
-	HOOK(fastprox, WMI_GetObject),
-	HOOK(fastprox, WMI_GetObjectAsync),
-	// TODO: Uncomment after adding Yara prolog detection for these non-exported hooks
-	//HOOK(fastprox, WMI_CreateInstanceEnum),
-	//HOOK(fastprox, WMI_CreateInstanceEnumAsync),
 
 	// File Hooks
 	HOOK(ntdll, NtQueryAttributesFile),
@@ -1780,6 +1790,104 @@ void revalidate_all_hooks(void)
 			invalidate_regions_for_hook(hooks+i);
 		}
 	}
+}
+
+static com_hook_t* com_hooks = NULL;
+static int num_com_hooks = 0;
+static int num_com_hooks_installed = 0;
+static int* com_hook_state = NULL;
+int com_hooks_initialized = 0;
+
+void init_com_hooks(void) {
+	com_hooks = g_com_hooks;
+	num_com_hooks = ARRAYSIZE(g_com_hooks);
+	com_hook_state = calloc(sizeof(*com_hook_state), num_com_hooks);
+	DebugOutput("DEBUG:Initialized %d com hooks", num_com_hooks);
+}
+
+int set_WbemLocator_hooks(PVOID pComObject, hook_t* hook) {
+	IWbemLocator* pIWebmLocator = (IWbemLocator*)pComObject;
+	DWORD old_protect;
+	VirtualProtect(hook, sizeof(*hook), PAGE_EXECUTE_READWRITE, &old_protect);
+	if (!strncmp(hook->funcname, "WbemLocator_ConnectServer", 25))
+		hook->addr = pIWebmLocator->lpVtbl->ConnectServer;
+	if (hook->addr) {
+		return hook_api(hook, g_config.hook_type);
+	}
+
+	return -1;
+}
+
+int set_IWbemServices_hooks(PVOID pComObject, hook_t* hook) {
+	IWbemServices* pIWbemServices = (IWbemServices*)pComObject;
+	DWORD old_protect;
+	VirtualProtect(hook, sizeof(*hook), PAGE_EXECUTE_READWRITE, &old_protect);
+	if (!strcmp(hook->funcname, "IWbemServices_ExecQuery")) {
+		hook->addr = pIWbemServices->lpVtbl->ExecQuery;
+	}
+	else if (!strncmp(hook->funcname, "IWbemServices_ExecQueryAsync", 28)) {
+		hook->addr = pIWbemServices->lpVtbl->ExecQueryAsync;
+	}
+	else if (!strncmp(hook->funcname, "IWbemServices_GetObjectW", 24)) {
+		hook->addr = pIWbemServices->lpVtbl->GetObject;
+	}
+	else if (!strncmp(hook->funcname, "IWbemServices_GetObjectAsync", 28)) {
+		hook->addr = pIWbemServices->lpVtbl->GetObjectAsync;
+	}
+	else if (!strcmp(hook->funcname, "IWbemServices_ExecMethod")) {
+		hook->addr = pIWbemServices->lpVtbl->ExecMethod;
+	}
+	else if (!strncmp(hook->funcname, "IWbemServices_ExecMethodAsync", 29)) {
+		hook->addr = pIWbemServices->lpVtbl->ExecMethodAsync;
+	}
+	else if (!strcmp(hook->funcname, "IWbemServices_CreateInstanceEnum")) {
+		hook->addr = pIWbemServices->lpVtbl->CreateInstanceEnum;
+	}
+	else if (!strncmp(hook->funcname, "IWbemServices_CreateInstanceEnumAsync", 37)) {
+		hook->addr = pIWbemServices->lpVtbl->CreateInstanceEnumAsync;
+	}
+	if (hook->addr) {
+		return hook_api(hook, g_config.hook_type);
+	}
+	return -1;
+}
+
+extern __declspec(thread) BOOL bHookViaWbemLocator;
+int set_com_hooks(REFCLSID	rclsid, REFIID riid, PVOID pComObject) {
+	if (!com_hooks_initialized) {
+		init_com_hooks();
+		com_hooks_initialized = 1;
+	}
+	if (num_com_hooks_installed < num_com_hooks) {
+		lasterror_t lasterrors;
+		get_lasterrors(&lasterrors);
+		__try {
+			for (int hook_idx = 0; hook_idx < num_com_hooks; hook_idx++) {
+				if (!com_hook_state[hook_idx]) {
+					com_hook_t* com_hook = &com_hooks[hook_idx];
+					hook_t* hook = &(com_hook->hook);
+					if ((rclsid && com_hook->rclsid && IsEqualCLSID(rclsid, com_hook->rclsid)) || (com_hook->riid && riid && IsEqualIID(riid, com_hook->riid)) || (!rclsid && !riid)) {
+						if (rclsid && riid) {
+							if (IsEqualCLSID(rclsid, &CLSID_WbemLocator) && IsEqualIID(riid, &IID_IWbemLocator)) {
+								return set_WbemLocator_hooks(pComObject, hook);
+							}
+							else if (!rclsid && !riid && !com_hook->rclsid && !com_hook->riid) {
+								if (bHookViaWbemLocator && !strncmp(hook->funcname, "IWbemServices_", 14)) {
+									return set_IWbemServices_hooks(pComObject, hook);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER) {
+			;
+		}
+		set_lasterrors(&lasterrors);
+	}
+
+	return -1;
 }
 
 PVOID g_dll_notify_cookie;

--- a/hooks.c
+++ b/hooks.c
@@ -182,15 +182,20 @@ hook_t full_hooks[] = {
 	// WMI Hooks
 #ifdef _WIN64
 	HOOK_WITHNAME(fastprox, WMI_Get, "?Get@CWbemObject@@UEAAJPEBGJPEAUtagVARIANT@@PEAJ2@Z"),
+	HOOK_WITHNAME(fastprox, WMI_Next, "?Next@CWbemObject@@UEAAJJPEAPEAGPEAUtagVARIANT@@PEAJ2@Z"),
 #else
 	HOOK_WITHNAME(fastprox, WMI_Get, "?Get@CWbemObject@@UAGJPBGJPAUtagVARIANT@@PAJ2@Z"),
+	HOOK_WITHNAME(fastprox, WMI_Next, "?Next@CWbemObject@@UAGJJPAPAGPAUtagVARIANT@@PAJ2@Z"),
 #endif
-	HOOK_NOTAIL(fastprox, WMI_ExecQuery, 6),
-	HOOK_NOTAIL(fastprox, WMI_ExecMethod, 8),
-	HOOK_NOTAIL(fastprox, WMI_ExecQueryAsync, 6),
-	HOOK_NOTAIL(fastprox, WMI_ExecMethodAsync, 7),
-	HOOK_NOTAIL(fastprox, WMI_GetObject, 6),
-	HOOK_NOTAIL(fastprox, WMI_GetObjectAsync, 5),
+	HOOK(fastprox, WMI_ExecQuery),
+	HOOK(fastprox, WMI_ExecQueryAsync),
+	HOOK(fastprox, WMI_ExecMethod),
+	HOOK(fastprox, WMI_ExecMethodAsync),
+	HOOK(fastprox, WMI_GetObject),
+	HOOK(fastprox, WMI_GetObjectAsync),
+	// TODO: Uncomment after adding Yara prolog detection for these non-exported hooks
+	//HOOK(fastprox, WMI_CreateInstanceEnum),
+	//HOOK(fastprox, WMI_CreateInstanceEnumAsync),
 
 	// File Hooks
 	HOOK(ntdll, NtQueryAttributesFile),

--- a/hooks.h
+++ b/hooks.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ntapi.h"
 #include <tlhelp32.h>
 #include <ncrypt.h>
+#include <Wbemidl.h>
 
 //
 // File Hooks
@@ -1263,69 +1264,96 @@ HOOKDEF(HRESULT, WINAPI, CoGetObject,
 
 // WMI Hooks
 HOOKDEF(HRESULT, WINAPI, WMI_Get,
-	PVOID		_this,
-	LPCWSTR		wszName,
-	LONG		lFlags,
-	VARIANT*	pVal,
-	LONG*		pType,
-	LONG*		plFlavor
+	_In_		PVOID	_this,
+	_In_		LPCWSTR	wszName,
+	_In_		LONG	lFlags,
+	_Out_		VARIANT	*pVal,
+	_Out_opt_	CIMTYPE	*pType,
+	_Out_opt_	LONG	*plFlavor
 );
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecQuery,
-	PVOID		_this,
-	const BSTR	strQueryLanguage,
-	const BSTR	strQuery,
-	LONG		lFlags,
-	PVOID		pCtx,
-	PVOID*		ppEnum
+HOOKDEF(HRESULT, WINAPI, WMI_Next,
+	_In_		PVOID	_this,
+	_In_		LONG	lFlags,
+	_Out_		BSTR	wszName,
+	_Out_		VARIANT	*pVal,
+	_Out_opt_	CIMTYPE	*pType,
+	_Out_opt_	LONG	*plFlavor
 );
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecQueryAsync,
-	PVOID		_this,
-	const BSTR	strQueryLanguage,
-	const BSTR	strQuery,
-	LONG		lFlags,
-	PVOID		pCtx,
-	PVOID		pResponseHandler
+HOOKDEF(HRESULT, WINAPI, WMI_ExecQuery,
+	_In_	PVOID					_this,
+	_In_	const BSTR				strQueryLanguage,
+	_In_	const BSTR				strQuery,
+	_In_	LONG					lFlags,
+	_In_	IWbemContext			*pCtx,
+	_Out_	IEnumWbemClassObject	**ppEnum
 );
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecMethod,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	const BSTR	strMethodName,
-	long		lFlags,
-	PVOID		pCtx,
-	PVOID		pInParams,
-	PVOID*		ppOutParams,
-	PVOID*		ppCallResult
+HOOKDEF(HRESULT, WINAPI, WMI_ExecQueryAsync,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strQueryLanguage,
+	_In_	const BSTR		strQuery,
+	_In_	LONG			lFlags,
+	_In_	IWbemContext	*pCtx,
+	_In_	IWbemObjectSink	*pResponseHandler
 );
 
-HOOKDEF_NOTAIL(WINAPI, WMI_ExecMethodAsync,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	const BSTR	strMethodName,
-	long		lFlags,
-	PVOID		pCtx,
-	PVOID		pInParams,
-	PVOID		pResponseHandler
+HOOKDEF(HRESULT, WINAPI, WMI_ExecMethod,
+	_In_	PVOID				_this,
+	_In_	const BSTR			strObjectPath,
+	_In_	const BSTR			strMethodName,
+	_In_	LONG				lFlags,
+	_In_	IWbemContext		*pCtx,
+	_In_	IWbemClassObject	*pInParams,
+	_Out_	IWbemClassObject	**ppOutParams,
+	_Out_	IWbemCallResult		**ppCallResult
 );
 
-HOOKDEF_NOTAIL(WINAPI, WMI_GetObject,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	LONG		lFlags,
-	PVOID		pCtx,
-	PVOID*		ppObject,
-	PVOID*		ppCallResult
+HOOKDEF(HRESULT, WINAPI, WMI_ExecMethodAsync,
+	_In_	PVOID				_this,
+	_In_	const BSTR			strObjectPath,
+	_In_	const BSTR			strMethodName,
+	_In_	LONG				lFlags,
+	_In_	IWbemContext		*pCtx,
+	_In_	IWbemClassObject	*pInParams,
+	_In_	IWbemObjectSink		*pResponseHandler
 );
 
-HOOKDEF_NOTAIL(WINAPI, WMI_GetObjectAsync,
-	PVOID		_this,
-	const BSTR	strObjectPath,
-	LONG		lFlags,
-	PVOID		pCtx,
-	PVOID		pResultHandler
+HOOKDEF(HRESULT, WINAPI, WMI_GetObject,
+	_In_	PVOID				_this,
+	_In_	const BSTR			strObjectPath,
+	_In_	LONG				lFlags,
+	_In_	IWbemContext		*pCtx,
+	_Out_	IWbemClassObject	**ppObject,
+	_Out_	IWbemCallResult		**ppCallResult
 );
+
+HOOKDEF(HRESULT, WINAPI, WMI_GetObjectAsync,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strObjectPath,
+	_In_	LONG			lFlags,
+	_In_	IWbemContext	*pCtx,
+	_In_	IWbemObjectSink	*pResultHandler
+);
+
+/*
+HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnum,
+	_In_	PVOID					_this,
+	_In_	const BSTR				strFilter,
+	_In_	long					lFlags,
+	_In_	IWbemContext			*pCtx,
+	_Out_	IEnumWbemClassObject	**ppEnum
+);
+
+HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnumAsync,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strFilter,
+	_In_	long			lFlags,
+	_In_	IWbemContext	*pCtx,
+	_In_	IWbemObjectSink	*pResponseHandler
+);
+*/
 
 // End of WMI Hooks
 

--- a/hooks.h
+++ b/hooks.h
@@ -24,6 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <ncrypt.h>
 #include <Wbemidl.h>
 
+#pragma comment(lib, "wbemuuid.lib")
+
 //
 // File Hooks
 //
@@ -1263,6 +1265,18 @@ HOOKDEF(HRESULT, WINAPI, CoGetObject,
 );
 
 // WMI Hooks
+HOOKDEF(HRESULT, WINAPI, WbemLocator_ConnectServer,
+	_In_	PVOID			_this,
+	_In_	const BSTR		strNetworkResource,
+	_In_	const BSTR		strUser,
+	_In_	const BSTR		strPassword,
+	_In_	const BSTR		strLocale,
+	_In_	long			lSecurityFlags,
+	_In_	const BSTR		strAuthority,
+	_In_	IWbemContext	*pCtx,
+	_Out_	IWbemServices	**ppNamespace
+);
+
 HOOKDEF(HRESULT, WINAPI, WMI_Get,
 	_In_		PVOID	_this,
 	_In_		LPCWSTR	wszName,
@@ -1337,7 +1351,6 @@ HOOKDEF(HRESULT, WINAPI, WMI_GetObjectAsync,
 	_In_	IWbemObjectSink	*pResultHandler
 );
 
-/*
 HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnum,
 	_In_	PVOID					_this,
 	_In_	const BSTR				strFilter,
@@ -1353,7 +1366,6 @@ HOOKDEF(HRESULT, WINAPI, WMI_CreateInstanceEnumAsync,
 	_In_	IWbemContext	*pCtx,
 	_In_	IWbemObjectSink	*pResponseHandler
 );
-*/
 
 // End of WMI Hooks
 


### PR DESCRIPTION
- WMI_Next hook added, which functions similar to WMI_Get for async related APIs on the backend (e.g. PowerShell cmdlet Get-CimInstance instead of Get-WmiObject
- Added initial spoofery for WMI
- Couple more hooks (to be officially added by Kevin at some point)
- Hopefully fixed weirdness with existing WMI hooks and NOTAIL shenanigans, just converted them to HOOK macros and we now log prior to calling the hook (which is effectively the same as NOTAIL)

Note: This PR is in a draft until @kevoreilly has time to add yara for CreateInstanceEnum/CreateInstanceEnumAsync