### PR TITLE
Add yara-timeout setting for in-monitor scans

### DIFF
--- a/CAPE/YaraHarness.c
+++ b/CAPE/YaraHarness.c
@@ -477,7 +477,7 @@ void YaraScan(PVOID Address, SIZE_T Size)
 	if (!YaraActivated)
 		return;
 
-	int Flags = 0, Timeout = 1, Result = ERROR_SUCCESS;
+	int Flags = 0, Result = ERROR_SUCCESS;
 
 	if (!Size)
 		return;
@@ -511,7 +511,7 @@ void YaraScan(PVOID Address, SIZE_T Size)
 
 	__try
 	{
-		Result = yr_rules_scan_mem(Rules, Address, Size, Flags, YaraCallback, Address, Timeout);
+		Result = yr_rules_scan_mem(Rules, Address, Size, Flags, YaraCallback, Address, g_config.yara_timeout);
 	}
 	__except(EXCEPTION_EXECUTE_HANDLER)
 	{

--- a/config.c
+++ b/config.c
@@ -1322,7 +1322,7 @@ void parse_config_line(char* line)
 		}
 		else if (!stricmp(key, "yara-timeout")) {
 			g_config.yara_timeout = (int)strtol(value, NULL, 10);
-			if (g_config.yara_timeout == 0)
+			if (g_config.yara_timeout <= 0)
 				DebugOutput("In-monitor YARA scan timeout set to unlimited.\n");
 			else
 				DebugOutput("In-monitor YARA scan timeout set to %d seconds.\n", g_config.yara_timeout);

--- a/config.c
+++ b/config.c
@@ -1320,6 +1320,13 @@ void parse_config_line(char* line)
 			else
 				DebugOutput("In-monitor YARA scans disabled.\n");
 		}
+		else if (!stricmp(key, "yara-timeout")) {
+			g_config.yara_timeout = (int)strtol(value, NULL, 10);
+			if (g_config.yara_timeout == 0)
+				DebugOutput("In-monitor YARA scan timeout set to unlimited.\n");
+			else
+				DebugOutput("In-monitor YARA scan timeout set to %d seconds.\n", g_config.yara_timeout);
+		}
 		else if (!stricmp(key, "amsidump")) {
 			g_config.amsidump = value[0] == '1';
 			if (g_config.amsidump)
@@ -1441,6 +1448,7 @@ void read_config(void)
 	g_config.api_cap = 5000;
 	g_config.api_rate_cap = 1;
 	g_config.yarascan = 1;
+	g_config.yara_timeout = 1;
 	g_config.loaderlock_scans = 1;
 	g_config.syscall = 1;
 

--- a/config.h
+++ b/config.h
@@ -234,6 +234,7 @@ struct _g_config {
 
 	// YARA scans
 	int yarascan;
+	int yara_timeout;
 
 	// AMSI dumps (Win10+)
 	int amsidump;


### PR DESCRIPTION
Hi, my first experience of using CAPE was spending hours trying to debug why no behavioural information or memory dumps were being reported. It turned out that I had been overambitious with YARA rules and the memory scanner was breaching its timeout (and not logging it) but there was no way to configure this hardcoded 1-second duration without completely recompiling and replacing capemon.dll.

Getting tired of doing that - so this PR adds a simple 'yara-timeout' monitor option that overrides the default - if supplied - otherwise there is no effect on behaviour.