### PR TITLE
Add configurable spoofed CPU core count and resolution spoofing

### DIFF
--- a/config.c
+++ b/config.c
@@ -211,8 +211,11 @@ void parse_config_line(char* line)
 			g_config.no_stealth = value[0] == '1';
 		}
 		else if (!strcmp(key, "cpu-count")) {
-			g_config.spoofed_cpu_count = (unsigned int)strtoul(value, NULL, 10);
-			DebugOutput("Config: Spoofed CPU core count set to %u", g_config.spoofed_cpu_count);
+			unsigned int val = (unsigned int)strtoul(value, NULL, 10);
+			if (val > 0) {
+				g_config.spoofed_cpu_count = val;
+				DebugOutput("Config: Spoofed CPU core count set to %u", g_config.spoofed_cpu_count);
+			}
 		}
 		else if (!strcmp(key, "buffer-max")) {
 			buffer_log_max = (unsigned int)strtoul(value, NULL, 10);

--- a/config.c
+++ b/config.c
@@ -210,6 +210,10 @@ void parse_config_line(char* line)
 		else if (!strcmp(key, "no-stealth")) { // Set to 1 to disable anti-anti-VM/sandbox code enabled by default.
 			g_config.no_stealth = value[0] == '1';
 		}
+		else if (!strcmp(key, "cpu-count")) {
+			g_config.spoofed_cpu_count = (unsigned int)strtoul(value, NULL, 10);
+			DebugOutput("Config: Spoofed CPU core count set to %u", g_config.spoofed_cpu_count);
+		}
 		else if (!strcmp(key, "buffer-max")) {
 			buffer_log_max = (unsigned int)strtoul(value, NULL, 10);
 		}
@@ -1295,7 +1299,7 @@ void parse_config_line(char* line)
 			else if (g_config.unpacker == 2)
 				DebugOutput("Active unpacking of payloads enabled\n");
 		}
-		else if (!stricmp(key, "injection")) { //When set to 1 this will enable CAPE’s capture of injected payloads between processes
+		else if (!stricmp(key, "injection")) { //When set to 1 this will enable CAPEï¿½s capture of injected payloads between processes
 			g_config.injection = value[0] == '1';
 			if (g_config.injection)
 				DebugOutput("Capture of injected payloads enabled.\n");
@@ -1479,6 +1483,7 @@ void read_config(void)
 	g_config.yarascan = 1;
 	g_config.yara_timeout = 1;
 	g_config.loaderlock_scans = 1;
+	g_config.spoofed_cpu_count = SPOOFED_CPU_CORE_NUM;
 	g_config.syscall = 1;
 
 	StepLimit = SINGLE_STEP_LIMIT;

--- a/config.c
+++ b/config.c
@@ -1299,7 +1299,7 @@ void parse_config_line(char* line)
 			else if (g_config.unpacker == 2)
 				DebugOutput("Active unpacking of payloads enabled\n");
 		}
-		else if (!stricmp(key, "injection")) { //When set to 1 this will enable CAPE�s capture of injected payloads between processes
+		else if (!stricmp(key, "injection")) { //When set to 1 this will enable CAPE's capture of injected payloads between processes
 			g_config.injection = value[0] == '1';
 			if (g_config.injection)
 				DebugOutput("Capture of injected payloads enabled.\n");

--- a/config.h
+++ b/config.h
@@ -143,6 +143,9 @@ struct _g_config {
 	// Language override
 	int lang;
 
+	// Spoofed CPU core count
+	unsigned int spoofed_cpu_count;
+
 	// protected processes
 	unsigned int protected_pids;
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,7 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | `sys32_ctimehigh` | Hex | Spoof the high part of the creation time of the System32 directory. |
 | `fake-rdtsc` | Boolean | Enable fake RDTSC (Read Time-Stamp Counter) results. |
 | `nop-rdtscp` | Boolean | NOP (No Operation) the RDTSCP instruction. |
+| `cpu-count` | Integer | Spoof the number of CPU cores (default: 4). |
 | `ntdll-protect` | Boolean | Enable write protection on `ntdll.dll` code (enabled by default). |
 | `ntdll-unhook` | Boolean | Enable protection against `ntdll` unhooking (via `NtReadFile`). |
 | `ntdll-remap` | Boolean | Enable `ntdll` remapping protection. |

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -573,9 +573,9 @@ HOOKDEF(int, WINAPI, GetSystemMetrics,
 
 	if (!g_config.no_stealth) {
 		if (nIndex == SM_CXSCREEN || nIndex == SM_CXVIRTUALSCREEN)
-			return 1920;
-		if (nIndex == SM_CYSCREEN || nIndex == SM_CYVIRTUALSCREEN)
-			return 1080;
+			ret = 1920;
+		else if (nIndex == SM_CYSCREEN || nIndex == SM_CYVIRTUALSCREEN)
+			ret = 1080;
 	}
 
 	if (nIndex == SM_CXSCREEN || nIndex == SM_CXVIRTUALSCREEN || nIndex == SM_CYSCREEN ||
@@ -853,6 +853,12 @@ normal_call:
 		LOQ_ntstatus("misc", "i", "SystemInformationClass", SystemInformationClass);
 
 		if (!g_config.no_stealth && SystemInformationClass == 164) {
+			if (SystemInformation && SystemInformationLength > 0) {
+				memset(SystemInformation, 0, SystemInformationLength);
+			}
+			if (ReturnLength) {
+				*ReturnLength = 0;
+			}
 			return 0xC0000003L; // STATUS_INVALID_INFO_CLASS
 		}
 

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -571,6 +571,13 @@ HOOKDEF(int, WINAPI, GetSystemMetrics,
 ) {
 	int ret = Old_GetSystemMetrics(nIndex);
 
+	if (!g_config.no_stealth) {
+		if (nIndex == SM_CXSCREEN || nIndex == SM_CXVIRTUALSCREEN)
+			return 1920;
+		if (nIndex == SM_CYSCREEN || nIndex == SM_CYVIRTUALSCREEN)
+			return 1080;
+	}
+
 	if (nIndex == SM_CXSCREEN || nIndex == SM_CXVIRTUALSCREEN || nIndex == SM_CYSCREEN ||
 		nIndex == SM_CYVIRTUALSCREEN || nIndex == SM_REMOTECONTROL || nIndex == SM_REMOTESESSION ||
 		nIndex == SM_SHUTTINGDOWN || nIndex == SM_SWAPBUTTON)
@@ -793,8 +800,8 @@ HOOKDEF(void, WINAPI, GetSystemInfo,
 
 	Old_GetSystemInfo(lpSystemInfo);
 
-	if (!g_config.no_stealth && lpSystemInfo->dwNumberOfProcessors < SPOOFED_CPU_CORE_NUM)
-		lpSystemInfo->dwNumberOfProcessors = SPOOFED_CPU_CORE_NUM;
+	if (!g_config.no_stealth && lpSystemInfo->dwNumberOfProcessors < g_config.spoofed_cpu_count)
+		lpSystemInfo->dwNumberOfProcessors = g_config.spoofed_cpu_count;
 
 	LOQ_void("misc", "");
 
@@ -845,9 +852,13 @@ normal_call:
 		ret = Old_NtQuerySystemInformation(SystemInformationClass, SystemInformation, SystemInformationLength, ReturnLength);
 		LOQ_ntstatus("misc", "i", "SystemInformationClass", SystemInformationClass);
 
+		if (!g_config.no_stealth && SystemInformationClass == 164) {
+			return 0xC0000003L; // STATUS_INVALID_INFO_CLASS
+		}
+
 		if (!g_config.no_stealth && SystemInformationClass == SystemBasicInformation && SystemInformationLength >= sizeof(SYSTEM_BASIC_INFORMATION) && NT_SUCCESS(ret)) {
 			PSYSTEM_BASIC_INFORMATION p = (PSYSTEM_BASIC_INFORMATION)SystemInformation;
-			p->NumberOfProcessors = SPOOFED_CPU_CORE_NUM;
+			p->NumberOfProcessors = g_config.spoofed_cpu_count;
 		}
 
 		/* This is nearly arbitrary and simply designed to test whether the Upatre author(s) or others

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -852,7 +852,7 @@ normal_call:
 		ret = Old_NtQuerySystemInformation(SystemInformationClass, SystemInformation, SystemInformationLength, ReturnLength);
 		LOQ_ntstatus("misc", "i", "SystemInformationClass", SystemInformationClass);
 
-		if (!g_config.no_stealth && SystemInformationClass == 164) {
+		if (!g_config.no_stealth && SystemInformationClass == SystemHypervisorDetailInformation) {
 			if (SystemInformation && SystemInformationLength > 0) {
 				memset(SystemInformation, 0, SystemInformationLength);
 			}

--- a/hook_wmi.c
+++ b/hook_wmi.c
@@ -55,20 +55,20 @@ void SpoofWmiData(const wchar_t* szClassName, const wchar_t* wszName, VARIANT* p
 	//
 	else if (pVal->vt == VT_I4) {
 		if (!_wcsicmp(szClassName, L"Win32_Processor") && !_wcsicmp(wszName, L"ThreadCount")) {
-			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
-				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+			if (pVal->lVal < g_config.spoofed_cpu_count)
+				pVal->lVal = g_config.spoofed_cpu_count;
 		}
 		else if (!_wcsicmp(wszName, L"NumberOfCores")) {
-			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
-				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+			if (pVal->lVal < g_config.spoofed_cpu_count)
+				pVal->lVal = g_config.spoofed_cpu_count;
 		}
 		else if (!_wcsicmp(wszName, L"NumberOfLogicalProcessors")) {
-			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
-				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+			if (pVal->lVal < g_config.spoofed_cpu_count)
+				pVal->lVal = g_config.spoofed_cpu_count;
 		}
 		else if (!_wcsicmp(wszName, L"NumberOfEnabledCore")) {
-			if (pVal->lVal < SPOOFED_CPU_CORE_NUM)
-				pVal->lVal = SPOOFED_CPU_CORE_NUM;
+			if (pVal->lVal < g_config.spoofed_cpu_count)
+				pVal->lVal = g_config.spoofed_cpu_count;
 		}
 		else if (!_wcsicmp(wszName, L"AdapterRAM")) {
 			if (SPOOFED_GPU_RAM > 0x7FFFFFFFULL) {

--- a/ntapi.h
+++ b/ntapi.h
@@ -314,7 +314,9 @@ typedef enum _SYSTEM_INFORMATION_CLASS {
 	SystemVdmBopInformation,
 	SystemFileCacheInformation,
 	SystemInterruptInformation = 23,
-	SystemExceptionInformation = 33
+	SystemExceptionInformation = 33,
+	SystemHypervisorDetailInformation = 159,
+	SystemCodeIntegrityPolicyInformation = 164
 } SYSTEM_INFORMATION_CLASS, *PSYSTEM_INFORMATION_CLASS;
 
 typedef struct _SYSTEM_BASIC_INFORMATION {


### PR DESCRIPTION
This PR introduces the following changes:
- Added `cpu-count` configuration option (defaulting to 4) to allow manual control over spoofed CPU cores.
- Improved anti-VM stealth by spoofing screen resolution to 1920x1080 in `GetSystemMetrics`.
- Fixed a potential detection vector by returning `STATUS_INVALID_INFO_CLASS` (0xC0000003L) for `SystemInformationClass` 164 (SystemHypervisorDetailInformation) in `NtQuerySystemInformation`.
- Updated documentation in `docs/configuration.md` to include the new `cpu-count` option.