### PR TITLE
log: Fix BSON array gaps by serializing empty/null variants as empty …

### DIFF
--- a/hook_vbscript.c
+++ b/hook_vbscript.c
@@ -27,20 +27,19 @@
     }
 
 void variant_to_string(VARIANT* var, char* buffer, size_t bufferSize) {
-    if (!var) {
-        if (bufferSize > 0) {
-            buffer[0] = '\0';
-        }
-        return;
-    }
-    if (var->vt & VT_BYREF) {
-        switch (var->vt & ~VT_BYREF) {
-            case VT_EMPTY:
-                if (bufferSize > 0) {
-                    buffer[0] = '\0';
-                }
-                break;
-            case 74:
+	if (!buffer || bufferSize == 0) {
+		return;
+	}
+	if (!var) {
+		buffer[0] = '\0';
+		return;
+	}
+	if (var->vt & VT_BYREF) {
+		switch (var->vt & ~VT_BYREF) {
+			case VT_EMPTY:
+				buffer[0] = '\0';
+				break;
+			case 74:
                 variant_to_string(var->pvRecord, buffer, bufferSize);
                 break;
             case VT_VARIANT:

--- a/hook_vbscript.c
+++ b/hook_vbscript.c
@@ -27,8 +27,19 @@
     }
 
 void variant_to_string(VARIANT* var, char* buffer, size_t bufferSize) {
+    if (!var) {
+        if (bufferSize > 0) {
+            buffer[0] = '\0';
+        }
+        return;
+    }
     if (var->vt & VT_BYREF) {
         switch (var->vt & ~VT_BYREF) {
+            case VT_EMPTY:
+                if (bufferSize > 0) {
+                    buffer[0] = '\0';
+                }
+                break;
             case 74:
                 variant_to_string(var->pvRecord, buffer, bufferSize);
                 break;
@@ -80,6 +91,11 @@ void variant_to_string(VARIANT* var, char* buffer, size_t bufferSize) {
         }
     } else {
         switch (var->vt) {
+            case VT_EMPTY:
+                if (bufferSize > 0) {
+                    buffer[0] = '\0';
+                }
+                break;
             case 74:
                 variant_to_string(var->pvRecord, buffer, bufferSize);
                 break;

--- a/log.c
+++ b/log.c
@@ -293,12 +293,16 @@ static void log_wstring(const wchar_t *str, int length)
 static void log_variant(VARIANT* var) {
 	char log_msg[32];
 	if (!var) {
-		// Objects that we recurse into may be null, bail here
+		// Log an empty string instead of bailing to avoid gaps in the BSON array
+		log_string("", 0);
 		return;
 	}
 
 	__try {
 		switch (var->vt) {
+			case VT_EMPTY:
+				log_string("", 0);
+				break;
 			case VT_NULL:
 				log_string("NULL", -1);
 				break;


### PR DESCRIPTION
…strings

Add NULL variant guards and explicit VT_EMPTY formatting to prevent monitor crashes and host-side parser mismatches.

Addresses 'log: Fix BSON array gaps by serializing empty/null variants as empty strings... names WMI_Get' in netlog.py processing