### PR TITLE
Adding minor fix for when DEBUG_COMMENTS is enabled.

### DIFF
--- a/CAPE/Debugger.c
+++ b/CAPE/Debugger.c
@@ -781,8 +781,8 @@ LONG WINAPI CAPEExceptionFilter(struct _EXCEPTION_POINTERS* ExceptionInfo)
 	}
 	else if (ExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_PRIVILEGED_INSTRUCTION || ExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_ILLEGAL_INSTRUCTION)
 	{
-#ifdef _WIN64
 		_DecodedInst instruction;
+#ifdef _WIN64
 		if (ide(&instruction, (void*)ExceptionInfo->ContextRecord->Rip) && !stricmp("rdtscp", instruction.mnemonic.p)) {
 			if (g_config.nop_rdtscp)
 			{

--- a/CAPE/Debugger.c
+++ b/CAPE/Debugger.c
@@ -781,7 +781,9 @@ LONG WINAPI CAPEExceptionFilter(struct _EXCEPTION_POINTERS* ExceptionInfo)
 	}
 	else if (ExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_PRIVILEGED_INSTRUCTION || ExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_ILLEGAL_INSTRUCTION)
 	{
+#if defined(_WIN64) || defined(DEBUG_COMMENTS)
 		_DecodedInst instruction;
+#endif
 #ifdef _WIN64
 		if (ide(&instruction, (void*)ExceptionInfo->ContextRecord->Rip) && !stricmp("rdtscp", instruction.mnemonic.p)) {
 			if (g_config.nop_rdtscp)


### PR DESCRIPTION
This fixes a case where `instruction` is uninitialized when `DEBUG_COMMENTS` is enabled and the build target is not `_WIN64`:

```
        // Bug: our distorm fails to dissassemble rdtscp on x86
        //if (ide(&instruction, (void*)ExceptionInfo->ContextRecord->Eip) && !stricmp("rdtscp", instruction.mnemonic.p)) {
        if (!memcmp((PUCHAR)ExceptionInfo->ContextRecord->Eip, "\x0f\x01\xf9", 3)) {
            if (g_config.nop_rdtscp)
            {
                DWORD OldProtect;
                VirtualProtect((PVOID)ExceptionInfo->ContextRecord->Eip, 3, PAGE_EXECUTE_READWRITE, &OldProtect);
                memcpy((PVOID)ExceptionInfo->ContextRecord->Eip, "\x90\x90\x90", 3);
                VirtualProtect((PVOID)ExceptionInfo->ContextRecord->Eip, 3, OldProtect, &OldProtect); 
            }
            else
            {
                DWORD64 Timestamp = __rdtsc();
                ExceptionInfo->ContextRecord->Eax = (DWORD)Timestamp;
                ExceptionInfo->ContextRecord->Edx = Timestamp >> 32;
                ExceptionInfo->ContextRecord->Eip += lde((void*)ExceptionInfo->ContextRecord->Eip);
            }
```

Moving the `_DecodedInst instruction` declaration before the `#ifdef _WIN64` fixes this case.