### PR TITLE
Update configuration reference with JIT MSIL and yarascan options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | `exclude-apis` | List | Colon-separated list of APIs to exclude from hooking. |
 | `exclude-dlls` | List | Colon-separated list of DLLs to exclude from hooking. |
 | `unhook-apis` | List | Colon-separated list of already hooked APIs to unhook at runtime. |
+| `unhook-on-terminate` | Boolean | If `true`, restore all hooked API original bytes to memory when the process terminates. |
 | `api-rate-cap` | Integer | Limit the rate of API logging. |
 | `api-cap` | Integer | Limit the total number of API logs allowed. |
 
@@ -84,7 +85,7 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | :--- | :--- | :--- |
 | `dump-limit` | Integer | Limit the number of payload dumps (default: 10). |
 | `dropped-limit` | Integer | Limit the number of dropped files logged (default: 100). |
-| `procdump` | Integer | Enable process memory dumping on exit/timeout (1 - dump if changed from image (default), 2 - always dump). |
+| `procdump` | Integer | Enable process memory dumping on exit/timeout (1 - dump if changed from image (default), 2 - always dump). Also enables automatic dumping of decrypted .NET JIT MSIL bytecode payloads. |
 | `procmemdump` | Boolean | Enable *full* process memory dumping. |
 | `import-reconstruction` | Boolean | Perform import reconstruction on process dumps. |
 | `dump-on-api` | List | Dump the calling module when specific APIs (colon-separated) are called. |
@@ -93,6 +94,9 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | `dump-crypto` | Boolean | Dump buffers from Crypto APIs. |
 | `dump-keys` | Boolean | Dump keys from `CryptImportKey`. |
 | `amsidump` | Boolean | Enable AMSI buffer dumping (Windows 10+). |
+| `yarascan` | Boolean | Enable in-memory YARA scanning of process memory, including JIT-compiled native code and decrypted MSIL bytecode payloads. |
+| `yara-timeout` | Integer | Timeout limit in milliseconds for in-memory YARA scanning (default: 60000). |
+| `dumpsize` | Integer | Maximum size in bytes allowed for a single raw memory dump. |
 | `jit-dumps` | Integer | Limit for .NET JIT cache dumps. |
 | `tlsdump` | Boolean | Enable dumping of TLS secrets. |
 | `regdump` | Boolean | Enable dumping of Registry data. |
@@ -106,11 +110,12 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | `debugger` | Boolean | Enable the internal debugger engine (implicitly set by bp/trace options, not used directly). |
 | `bp0`...`bp3` | Addr/String | Set hardware breakpoint. Format: `0xAddress`, `Module:Export`, `zero` (clear), or `ep` (entrypoint). |
 | `br0`, `br1` | Addr/String | Set "break-on-return" addresses. |
-| `bp` | List | Colon-separated list of addresses for software breakpoints. |
 | `sysbp` | List | Colon-separated list of addresses for syscall breakpoints. |
 | `sysbpmode` | Integer | Mode for syscall breakpoints. |
+| `softbpmode` | Integer | Execution mode behavior for software breakpoints. |
 | `break-on-return` | List | Colon-separated list of APIs to break on return. |
 | `break-on-jit` | Boolean | Break on .NET JIT compiled native code. |
+| `idbg` | Boolean | Enable interactive remote debugger interface / locks. |
 | `trace-all` | Boolean | Enable full execution tracing. |
 | `trace-into-api` | List | Colon-separated list of APIs to trace into. |
 | `branch-trace` | Boolean | Enable branch tracing. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | :--- | :--- | :--- |
 | `dump-limit` | Integer | Limit the number of payload dumps (default: 10). |
 | `dropped-limit` | Integer | Limit the number of dropped files logged (default: 100). |
-| `procdump` | Integer | Enable process memory dumping on exit/timeout (1 - dump if changed from image (default), 2 - always dump). Also enables automatic dumping of decrypted .NET JIT MSIL bytecode payloads. |
+| `procdump` | Integer | Enable process memory dumping on exit/timeout (1 - dump if changed from image (default), 2 - always dump). |
 | `procmemdump` | Boolean | Enable *full* process memory dumping. |
 | `import-reconstruction` | Boolean | Perform import reconstruction on process dumps. |
 | `dump-on-api` | List | Dump the calling module when specific APIs (colon-separated) are called. |
@@ -97,7 +97,7 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | `yarascan` | Boolean | Enable in-memory YARA scanning of process memory, including JIT-compiled native code and decrypted MSIL bytecode payloads. |
 | `yara-timeout` | Integer | Timeout limit in milliseconds for in-memory YARA scanning (default: 60000). |
 | `dumpsize` | Integer | Maximum size in bytes allowed for a single raw memory dump. |
-| `jit-dumps` | Integer | Limit for .NET JIT cache dumps. |
+| `jit-dumps` | Integer | Limit for .NET JIT cache and MSIL bytecode dumps. |
 | `tlsdump` | Boolean | Enable dumping of TLS secrets. |
 | `regdump` | Boolean | Enable dumping of Registry data. |
 | `unpacker` | Integer | `1` = Passive unpacking (default), `2` = Active unpacking. |
@@ -110,12 +110,13 @@ They are typically defined in the analysis configuration file (e.g., `config.ini
 | `debugger` | Boolean | Enable the internal debugger engine (implicitly set by bp/trace options, not used directly). |
 | `bp0`...`bp3` | Addr/String | Set hardware breakpoint. Format: `0xAddress`, `Module:Export`, `zero` (clear), or `ep` (entrypoint). |
 | `br0`, `br1` | Addr/String | Set "break-on-return" addresses. |
+| `bp` | List | Colon-separated list of addresses for software breakpoints. |
 | `sysbp` | List | Colon-separated list of addresses for syscall breakpoints. |
 | `sysbpmode` | Integer | Mode for syscall breakpoints. |
 | `softbpmode` | Integer | Execution mode behavior for software breakpoints. |
 | `break-on-return` | List | Colon-separated list of APIs to break on return. |
 | `break-on-jit` | Boolean | Break on .NET JIT compiled native code. |
-| `idbg` | Boolean | Enable interactive remote debugger interface / locks. |
+| `idbg` | Boolean | Enable interactive remote debugger interface (CAPEsolo internal). |
 | `trace-all` | Boolean | Enable full execution tracing. |
 | `trace-into-api` | List | Colon-separated list of APIs to trace into. |
 | `branch-trace` | Boolean | Enable branch tracing. |


### PR DESCRIPTION
  1. Hooking Behavior Section
   * unhook-on-terminate: (Boolean) If true, attempt to restore all hooked API bytes back to their original state in memory when the process exits. (This is the highly important feature added in the previous merge on Aug 12, 2026, which was completely undocumented!).

  2. Dumping & Payloads Section
   * yarascan: (Boolean) Enable in-memory YARA scanning of process memory, including JIT-compiled native code and decrypted MSIL bytecode payloads.
   * yara-timeout: (Integer) Maximum timeout limit in milliseconds for in-memory YARA scanning (default: 60000).
   * dumpsize: (Integer) Maximum size in bytes allowed for an individual raw memory dump (prevents memory exhaustion from large dumps).

  3. Debugging & Tracing (Advanced) Section
   * softbpmode: (Integer) Execution mode behavior for software breakpoints.
   * idbg: (Boolean) Enable interactive remote debugger interface / locks.