### PR TITLE
Optimize hot-path string and path resolution via Small Buffer Optimization (SBO)

### DIFF
--- a/log.c
+++ b/log.c
@@ -255,39 +255,91 @@ static void log_ptr(void *value)
 static void log_string(const char *str, int length)
 {
 	int ret;
-	char *utf8s;
+	char stack_buf[2048];
+	char *utf8s = stack_buf;
 	int utf8len;
+	BOOL allocated = FALSE;
 
 	if (str == NULL) {
 		bson_append_string_n( g_bson, g_istr, "", 0 );
 		return;
 	}
-	utf8s = utf8_string(str, length);
-	utf8len = * (int *) utf8s;
+
+	if (length == -1)
+		length = (int)strlen(str);
+
+	utf8len = utf8_strlen_ascii(str, length);
+	if (utf8len + 4 > sizeof(stack_buf)) {
+		utf8s = malloc(utf8len + 4);
+		allocated = TRUE;
+	}
+
+	if (utf8s == NULL) {
+		bson_append_string_n(g_bson, g_istr, "", 0);
+		return;
+	}
+
+	*((int *) utf8s) = utf8len;
+	int pos = 4;
+	const char *p = str;
+	int temp_len = length;
+	while (temp_len-- != 0) {
+		pos += utf8_do_encode(*p++, (unsigned char *) &utf8s[pos]);
+	}
+
 	ret = bson_append_binary( g_bson, g_istr, BSON_BIN_BINARY, utf8s+4, utf8len );
 	if (ret == BSON_ERROR) {
 		bson_append_string_n(g_bson, g_istr, "", 0);
 	}
-	free(utf8s);
+
+	if (allocated) {
+		free(utf8s);
+	}
 }
 
 static void log_wstring(const wchar_t *str, int length)
 {
 	int ret;
-	char *utf8s;
+	char stack_buf[2048];
+	char *utf8s = stack_buf;
 	int utf8len;
+	BOOL allocated = FALSE;
 
 	if (str == NULL) {
 		bson_append_string_n( g_bson, g_istr, "", 0 );
 		return;
 	}
-	utf8s = utf8_wstring(str, length);
-	utf8len = * (int *) utf8s;
+
+	if (length == -1)
+		length = lstrlenW(str);
+
+	utf8len = utf8_strlen_unicode(str, length);
+	if (utf8len + 4 > sizeof(stack_buf)) {
+		utf8s = malloc(utf8len + 4);
+		allocated = TRUE;
+	}
+
+	if (utf8s == NULL) {
+		bson_append_string_n(g_bson, g_istr, "", 0);
+		return;
+	}
+
+	*((int *) utf8s) = utf8len;
+	int pos = 4;
+	const wchar_t *p = str;
+	int temp_len = length;
+	while (temp_len-- != 0) {
+		pos += utf8_do_encode(*p++, (unsigned char *) &utf8s[pos]);
+	}
+
 	ret = bson_append_binary( g_bson, g_istr, BSON_BIN_BINARY, utf8s+4, utf8len );
 	if (ret == BSON_ERROR) {
 		bson_append_string_n(g_bson, g_istr, "", 0);
 	}
-	free(utf8s);
+
+	if (allocated) {
+		free(utf8s);
+	}
 }
 
 static void log_variant(VARIANT* var) {

--- a/misc.c
+++ b/misc.c
@@ -1258,8 +1258,14 @@ out:
 
 wchar_t *ensure_absolute_unicode_path(wchar_t *out, const wchar_t *in)
 {
-	wchar_t *tmpout = NULL;
-	wchar_t *nonexistent = NULL;
+	unsigned int path_buf_size = 2048;
+	wchar_t stack_tmpout[2048];
+	wchar_t stack_nonexistent[2048];
+	wchar_t *tmpout = stack_tmpout;
+	wchar_t *nonexistent = stack_nonexistent;
+	BOOL allocated_tmpout = FALSE;
+	BOOL allocated_nonexistent = FALSE;
+
 	unsigned int lenchars;
 	unsigned int nonexistentidx;
 	wchar_t *pathcomponent = NULL;
@@ -1291,62 +1297,85 @@ wchar_t *ensure_absolute_unicode_path(wchar_t *out, const wchar_t *in)
 		goto out;
 	}
 
-	tmpout = malloc(32768 * sizeof(wchar_t));
-	nonexistent = malloc(32768 * sizeof(wchar_t));
-
-	if (tmpout == NULL || nonexistent == NULL)
-		goto normal_copy;
+	if (inlen >= 2000) {
+		path_buf_size = 32768;
+		tmpout = malloc(path_buf_size * sizeof(wchar_t));
+		nonexistent = malloc(path_buf_size * sizeof(wchar_t));
+		if (tmpout == NULL || nonexistent == NULL) {
+			if (tmpout) free(tmpout);
+			if (nonexistent) free(nonexistent);
+			tmpout = stack_tmpout;
+			nonexistent = stack_nonexistent;
+			path_buf_size = 2048;
+		} else {
+			allocated_tmpout = TRUE;
+			allocated_nonexistent = TRUE;
+		}
+	}
 
 	if (!wcsnicmp(inadj, L"\\device\\", 8) || !wcsnicmp(inadj, L"\\systemroot", 11)) {
 		// handle \\Device\\* and \\systemroot\\*
 		unsigned int matchlen;
-		wchar_t *tmpout2;
+		wchar_t stack_tmpout2[2048];
+		wchar_t *tmpout2 = stack_tmpout2;
+		BOOL allocated_tmpout2 = FALSE;
 		wchar_t *retstr = get_matching_unicode_specialname(inadj, &matchlen);
 		if (retstr == NULL)
 			goto normal_copy;
 		// rewrite \\Device\\HarddiskVolumeX etc to the appropriate drive letter
-		tmpout2 = malloc(32768 * sizeof(wchar_t));
-		if (tmpout2 == NULL)
-			goto normal_copy;
+		if (path_buf_size > 2048) {
+			tmpout2 = malloc(path_buf_size * sizeof(wchar_t));
+			if (tmpout2 == NULL) {
+				tmpout2 = stack_tmpout2;
+			} else {
+				allocated_tmpout2 = TRUE;
+			}
+		}
 
 		wcscpy(tmpout2, L"\\\\?\\");
 		wcscat(tmpout2, retstr);
-		wcsncat(tmpout2, inadj + matchlen, 32768 - 4 - 3);
-		if (!GetFullPathNameW(tmpout2, 32768, tmpout, NULL)) {
-			free(tmpout2);
+		wcsncat(tmpout2, inadj + matchlen, path_buf_size - 4 - 3);
+		if (!GetFullPathNameW(tmpout2, path_buf_size, tmpout, NULL)) {
+			if (allocated_tmpout2) free(tmpout2);
 			goto normal_copy;
 		}
-		free(tmpout2);
+		if (allocated_tmpout2) free(tmpout2);
 	}
 	else if (inlen > 1 && inadj[1] == L':') {
-		wchar_t *tmpout2;
-
-		tmpout2 = malloc(32768 * sizeof(wchar_t));
-		if (tmpout2 == NULL)
-			goto normal_copy;
+		wchar_t stack_tmpout2[2048];
+		wchar_t *tmpout2 = stack_tmpout2;
+		BOOL allocated_tmpout2 = FALSE;
+		if (path_buf_size > 2048) {
+			tmpout2 = malloc(path_buf_size * sizeof(wchar_t));
+			if (tmpout2 == NULL) {
+				tmpout2 = stack_tmpout2;
+			} else {
+				allocated_tmpout2 = TRUE;
+			}
+		}
 
 		wcscpy(tmpout2, L"\\\\?\\");
-		wcsncat(tmpout2, inadj, 32768 - 4);
-		if (!GetFullPathNameW(tmpout2, 32768, tmpout, NULL)) {
-			free(tmpout2);
+		wcsncat(tmpout2, inadj, path_buf_size - 4);
+		if (!GetFullPathNameW(tmpout2, path_buf_size, tmpout, NULL)) {
+			if (allocated_tmpout2) free(tmpout2);
 			goto normal_copy;
 		}
-		free(tmpout2);
+		if (allocated_tmpout2) free(tmpout2);
 	}
 	else if (is_globalroot) {
 		// handle \\??\\*\\*
 		goto globalroot_copy;
 	}
 	else {
-		if (!GetFullPathNameW(inadj, 32768, tmpout, NULL))
+		if (!GetFullPathNameW(inadj, path_buf_size, tmpout, NULL))
 			goto normal_copy;
 	}
 
 	lenchars = 0;
-	nonexistentidx = 32767;
+	nonexistentidx = path_buf_size - 1;
 	nonexistent[nonexistentidx] = L'\0';
 	while (lenchars == 0) {
-		lenchars = GetLongPathNameW(tmpout, out, 32768);
+		lenchars = GetLongPathNameW(tmpout, out, path_buf_size);
 		if (lenchars)
 			break;
 		if (GetLastError() != ERROR_FILE_NOT_FOUND && GetLastError() != ERROR_PATH_NOT_FOUND && GetLastError() != ERROR_INVALID_NAME)
@@ -1359,7 +1388,7 @@ wchar_t *ensure_absolute_unicode_path(wchar_t *out, const wchar_t *in)
 		memcpy(nonexistent + nonexistentidx, pathcomponent, pathcomponentlen * sizeof(wchar_t));
 		*pathcomponent = L'\0';
 	}
-	wcsncat(out, nonexistent + nonexistentidx, 32768 - lstrlenW(out));
+	wcsncat(out, nonexistent + nonexistentidx, path_buf_size - lstrlenW(out));
 
 	if (!wcsncmp(out, L"\\\\?\\", 4))
 		memmove(out, out + 4, (lstrlenW(out) + 1 - 4) * sizeof(wchar_t));
@@ -1373,18 +1402,18 @@ wchar_t *ensure_absolute_unicode_path(wchar_t *out, const wchar_t *in)
 
 globalroot_copy:
 	wcscpy(out, L"\\??\\");
-	wcsncat(out, inadj, 32768 - 4);
+	wcsncat(out, inadj, path_buf_size - 4);
 	goto out;
 
 normal_copy:
-	wcsncpy(out, inadj, 32768);
+	wcsncpy(out, inadj, path_buf_size);
 	if (!wcsncmp(out, L"\\\\?\\", 4))
 		memmove(out, out + 4, (lstrlenW(out) + 1 - 4) * sizeof(wchar_t));
 out:
-	out[32767] = L'\0';
-	if (tmpout)
+	out[path_buf_size - 1] = L'\0';
+	if (allocated_tmpout && tmpout)
 		free(tmpout);
-	if (nonexistent)
+	if (allocated_nonexistent && nonexistent)
 		free(nonexistent);
 	if (out[1] == L':' && out[2] == L'\\')
 		out[0] = toupper(out[0]);
@@ -1485,15 +1514,27 @@ wchar_t *get_full_key_pathW(HKEY registry, const wchar_t *in, PKEY_NAME_INFORMAT
 	wchar_t *u;
 	wchar_t *ret;
 	unsigned short idx = 0;
+	wchar_t stack_buf[1024];
+	size_t in_len = in ? wcslen(in) : 0;
+	unsigned int max_capacity = MAX_KEY_BUFLEN;
+	BOOL allocated = FALSE;
 
 	memset(&objattr, 0, sizeof(objattr));
 
-	keystr.Buffer = calloc(1, MAX_KEY_BUFLEN);
-	keystr.MaximumLength = MAX_KEY_BUFLEN;
+	if (in_len < 1000) {
+		keystr.Buffer = stack_buf;
+		keystr.MaximumLength = sizeof(stack_buf);
+		max_capacity = sizeof(stack_buf);
+		memset(stack_buf, 0, sizeof(stack_buf));
+	} else {
+		keystr.Buffer = calloc(1, MAX_KEY_BUFLEN);
+		keystr.MaximumLength = MAX_KEY_BUFLEN;
+		allocated = TRUE;
+	}
 	objattr.ObjectName = &keystr;
 
 	if (in) {
-		for (p = in, u = keystr.Buffer; *p && idx < (MAX_KEY_BUFLEN / sizeof(wchar_t) - 1); p++, u++, idx++) {
+		for (p = in, u = keystr.Buffer; *p && idx < (max_capacity / sizeof(wchar_t) - 1); p++, u++, idx++) {
 			*u = *p;
 			// normalize duplicate backslashes in the user-provided string as the registry APIs will use them without error
 			if (*p == L'\\') {
@@ -1511,7 +1552,9 @@ wchar_t *get_full_key_pathW(HKEY registry, const wchar_t *in, PKEY_NAME_INFORMAT
 	objattr.RootDirectory = registry;
 
 	ret = get_key_path(&objattr, keybuf, len);
-	free(keystr.Buffer);
+	if (allocated && keystr.Buffer) {
+		free(keystr.Buffer);
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Replaces high-frequency heap allocations (malloc/calloc/free) in ensure_absolute_unicode_path, get_full_key_pathW, log_string, and log_wstring with stack-allocated local buffers (SBO). Retains dynamic allocation fallback for oversized paths or strings to preserve complete compatibility.