### PR TITLE
Optimize concurrent logging via adaptive spin-retry loops

### DIFF
--- a/log.c
+++ b/log.c
@@ -507,8 +507,22 @@ void loq(int index, const char *category, const char *name,
 
 	hook_disable();
 
-	if (!TryEnterCriticalSection(&g_mutex))
-		goto exit;
+	{
+		int retries = 100;
+		BOOL acquired = FALSE;
+
+		while (retries-- > 0) {
+			if (TryEnterCriticalSection(&g_mutex)) {
+				acquired = TRUE;
+				break;
+			}
+			SwitchToThread();
+		}
+
+		if (!acquired) {
+			goto exit;
+		}
+	}
 
 	if (!special_api_triggered)
 		last_api_logged = API_OTHER;


### PR DESCRIPTION
Replaces immediate exit/drop of logging events on mutex contention in loq with an adaptive retry loop. Spins up to 100 times and yields processing slices using SwitchToThread() before falling back, preventing silents drops of API logging events under intense multi-threaded workloads.