### PR TITLE
Implement defensive pointer safeguarding to prevent anti-sandbox crash tricks

### DIFF
--- a/ignore.c
+++ b/ignore.c
@@ -76,21 +76,36 @@ int is_ignored_file_unicode(const wchar_t *fname, unsigned int length)
 {
 	struct _ignored_file_t *f = g_ignored_files;
 	unsigned int i;
-	for (i = 0; i < ARRAYSIZE(g_ignored_files); i++, f++) {
-		if(f->flags == FLAG_NONE && length == f->length &&
-				!wcsnicmp(fname, f->unicode, length)) {
-			return 1;
+	__try {
+		if (fname == NULL || length == 0)
+			return 0;
+		for (i = 0; i < ARRAYSIZE(g_ignored_files); i++, f++) {
+			if(f->flags == FLAG_NONE && length == f->length &&
+					!wcsnicmp(fname, f->unicode, length)) {
+				return 1;
+			}
+			else if(f->flags == FLAG_BEGINS_WITH && length >= f->length &&
+					!wcsnicmp(fname, f->unicode, f->length)) {
+				return 1;
+			}
 		}
-		else if(f->flags == FLAG_BEGINS_WITH && length >= f->length &&
-				!wcsnicmp(fname, f->unicode, f->length)) {
-			return 1;
-		}
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		;
 	}
 	return 0;
 }
 
 int is_ignored_file_objattr(const OBJECT_ATTRIBUTES *obj)
 {
-	return is_ignored_file_unicode(obj->ObjectName->Buffer,
-		obj->ObjectName->Length / sizeof(wchar_t));
+	__try {
+		if (obj != NULL && obj->ObjectName != NULL && obj->ObjectName->Buffer != NULL) {
+			return is_ignored_file_unicode(obj->ObjectName->Buffer,
+				obj->ObjectName->Length / sizeof(wchar_t));
+		}
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		;
+	}
+	return 0;
 }

--- a/misc.c
+++ b/misc.c
@@ -884,11 +884,22 @@ BOOL file_exists(const OBJECT_ATTRIBUTES *obj)
 {
 	FILE_BASIC_INFORMATION basic_information;
 	wchar_t pipe_base_name[] = L"\\??\\pipe\\";
-	if (!wcsnicmp(obj->ObjectName->Buffer, pipe_base_name, wcslen(pipe_base_name)))
-		return FALSE;
-	NTSTATUS ret = pNtQueryAttributesFile(obj, &basic_information);
-	if (NT_SUCCESS(ret) || ret == STATUS_INVALID_DEVICE_REQUEST)
-		return TRUE;
+	NTSTATUS ret;
+
+	__try {
+		if (obj == NULL || obj->ObjectName == NULL || obj->ObjectName->Buffer == NULL)
+			return FALSE;
+
+		if (!wcsnicmp(obj->ObjectName->Buffer, pipe_base_name, wcslen(pipe_base_name)))
+			return FALSE;
+
+		ret = pNtQueryAttributesFile(obj, &basic_information);
+		if (NT_SUCCESS(ret) || ret == STATUS_INVALID_DEVICE_REQUEST)
+			return TRUE;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		;
+	}
 	return FALSE;
 }
 


### PR DESCRIPTION
Introduces Structured Exception Handling (SEH) and rigorous NULL/bounds validation inside file_exists, is_ignored_file_unicode, and is_ignored_file_objattr. This prevents malware from crashing the capemon hook DLL by passing malformed OBJECT_ATTRIBUTES or NULL buffers, while still passing the bad pointers unmodified down to real Windows to preserve native exception behaviors.