### PR TITLE
Implement COM/WMI and Cryptographic out-pointer safeguarding

### DIFF
--- a/hook_com.c
+++ b/hook_com.c
@@ -55,7 +55,7 @@ HOOKDEF(HRESULT, WINAPI, WbemLocator_ConnectServer,
 	HRESULT ret;
 	ret = Old_WbemLocator_ConnectServer(_this, strNetworkResource, strUser, strPassword, strLocale, lSecurityFlags, strAuthority, pCtx, ppNamespace);
 
-	if (ret == S_OK && (
+	if (ret == S_OK && ppNamespace && *ppNamespace && (
 		ContainsNamespace(strNetworkResource, L"ROOT\\CIMV2") ||
 		ContainsNamespace(strNetworkResource, L"ROOT\\SecurityCenter2") ||
 		ContainsNamespace(strNetworkResource, L"ROOT\\Microsoft\\Windows\\Defender") ||

--- a/hook_crypto.c
+++ b/hook_crypto.c
@@ -461,7 +461,7 @@ HOOKDEF(BOOL, WINAPI, CryptImportKey,
 	HCRYPTKEY  *phKey
 ) {
 	BOOL ret = Old_CryptImportKey(hProv, pbData, dwDataLen, hPubKey, dwFlags, phKey);
-	LOQ_bool("crypto", "bhpi", "KeyBlob", dwDataLen, pbData, "Flags", dwFlags,  "CryptKey", *phKey, "Length", dwDataLen);
+	LOQ_bool("crypto", "bhpi", "KeyBlob", dwDataLen, pbData, "Flags", dwFlags,  "CryptKey", phKey ? *phKey : 0, "Length", dwDataLen);
 	return ret;
 }
 
@@ -476,7 +476,7 @@ HOOKDEF(SECURITY_STATUS, WINAPI, NCryptImportKey,
 	DWORD			  dwFlags
 ) {
 	BOOL ret = Old_NCryptImportKey(hProvider, hImportKey, pszBlobType, pParameterList, phKey, pbData, cbData, dwFlags);
-	LOQ_bool("crypto", "bhp", "KeyBlob", cbData, pbData, "Flags", dwFlags,  "CryptKey", *phKey, "Length", cbData);
+	LOQ_bool("crypto", "bhp", "KeyBlob", cbData, pbData, "Flags", dwFlags,  "CryptKey", phKey ? *phKey : 0, "Length", cbData);
 	return ret;
 }
 
@@ -541,7 +541,7 @@ HOOKDEF(NTSTATUS, WINAPI, BCryptImportKey,
 	ULONG				dwFlags
 ) {
 	NTSTATUS ret = Old_BCryptImportKey(hAlgorithm, hImportKey, pszBlobType, phKey, pbKeyObject, cbKeyObject, pbInput, cbInput, dwFlags);
-	LOQ_ntstatus("crypto", "bhpi", "KeyBlob", cbInput, pbInput, "Flags", dwFlags, "CryptKey", *phKey, "Length", cbInput);
+	LOQ_ntstatus("crypto", "bhpi", "KeyBlob", cbInput, pbInput, "Flags", dwFlags, "CryptKey", phKey ? *phKey : 0, "Length", cbInput);
 	return ret;
 }
 
@@ -561,7 +561,7 @@ HOOKDEF(NTSTATUS, WINAPI, BCryptImportKeyPair,
 		DebugOutput("BCryptImportKeyPair hook: Dumped ImportKey buffer at 0x%p (size 0x%x).\n", pbInput, cbInput);
 	}
 	NTSTATUS ret = Old_BCryptImportKeyPair(hAlgorithm, hImportKey, pszBlobType, phKey, pbInput, cbInput, dwFlags);
-	LOQ_ntstatus("crypto", "bhpi", "KeyBlob", cbInput, pbInput, "Flags", dwFlags, "CryptKey", *phKey, "Length", cbInput);
+	LOQ_ntstatus("crypto", "bhpi", "KeyBlob", cbInput, pbInput, "Flags", dwFlags, "CryptKey", phKey ? *phKey : 0, "Length", cbInput);
 	return ret;
 }
 


### PR DESCRIPTION
Safeguards WbemLocator_ConnectServer in hook_com.c and CryptImportKey, NCryptImportKey, BCryptImportKey, BCryptImportKeyPair in hook_crypto.c. Prevents crashes when processing malformed or NULL output-key/interface handle pointers (*phKey / *ppNamespace), rendering the hook DLL extremely resilient against evasion crash exploits.