### PR TITLE
Resolve VS2022 detonation failures via compiler safety mitigations bypass (Issue-61)

### DIFF
--- a/capemon.vcxproj
+++ b/capemon.vcxproj
@@ -151,7 +151,8 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>.\libyara\include;.\bson;.\distorm\include;C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\WTL81\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
       <EnablePREfast>false</EnablePREfast>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/Qsafe_fp_loads %(AdditionalOptions)</AdditionalOptions>
@@ -186,7 +187,8 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>.\libyara\include;.\bson;.\distorm\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <ControlFlowGuard>false</ControlFlowGuard>
       <EnablePREfast>false</EnablePREfast>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Explicitly disables BufferSecurityCheck (/GS-) and ControlFlowGuard (/guard:cf-) inside all Release configurations (x86 and x64) in capemon.vcxproj. This prevents instant security-cookie or CFG fast-fail crashes during early hook execution bootstrap inside injected modules (e.g. explorer.exe during PowerLoader hijack), enabling flawless detonation when capemon is compiled with modern compilers like VS2022.