### PR TITLE
Defeat thread-yield debugger checks and single-stepping detections

### DIFF
--- a/hook_thread.c
+++ b/hook_thread.c
@@ -946,12 +946,23 @@ HOOKDEF(NTSTATUS, WINAPI, NtQueryInformationThread,
 	return ret;
 }
 
+#define STATUS_NO_YIELD_PERFORMED ((NTSTATUS)0x40000024)
+
 HOOKDEF(NTSTATUS, WINAPI, NtYieldExecution,
 	VOID
 ) {
-	NTSTATUS ret = 0;
+	NTSTATUS ret;
 	LOQ_void("threading", "");
+	
+	// Execute the real yield to prevent thread starvation and spinlock deadlocks
 	ret = Old_NtYieldExecution();
+	
+	// Deceive debugger-single-stepping loops (which check for STATUS_NO_YIELD_PERFORMED)
+	// by always reporting that a yield successfully occurred.
+	if (ret == STATUS_NO_YIELD_PERFORMED) {
+		ret = 0; // STATUS_SUCCESS
+	}
+	
 	return ret;
 }
 


### PR DESCRIPTION
intercepts thread yielding requests inside the existing NtYieldExecution gateway hook in hook_thread.c:
1. Executes the actual thread yielding operation via Old_NtYieldExecution() to maintain absolute, deadlock-free thread scheduling and synchronization compatibility across all system DLLs and malware samples.
2. Intercepts and overwrites the STATUS_NO_YIELD_PERFORMED (0x40000024) status code (triggered legally or via debugger stepping) to STATUS_SUCCESS (0x00000000).
3. Completely deceives single-stepping validation loops into believing execution scheduling is fully unhindered, neutralizing the anti-debugging checks with zero performance penalty.
