### PR TITLE
chore: rename no_stealth to bypass_antivm for clarity

### DIFF
--- a/capemon.c
+++ b/capemon.c
@@ -679,7 +679,7 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD dwReason, LPVOID lpReserved)
 		//init_watchdog();
 
 #ifndef _WIN64
-		if (!g_config.no_stealth) {
+		if (!g_config.bypass_antivm) {
 			/* for people too lazy to setup VMs properly */
 			PEB *peb = get_peb();
 			if (peb->NumberOfProcessors == 1)

--- a/config.c
+++ b/config.c
@@ -207,8 +207,8 @@ void parse_config_line(char* line)
 		else if (!strcmp(key, "terminate-event")) {
 			strncpy(g_config.terminate_event_name, value, ARRAYSIZE(g_config.terminate_event_name));
 		}
-		else if (!strcmp(key, "no-stealth")) { // Set to 1 to disable anti-anti-VM/sandbox code enabled by default.
-			g_config.no_stealth = value[0] == '1';
+		else if (!strcmp(key, "bypass-antivm")) { // Set to 1 to disable anti-anti-VM/sandbox code enabled by default.
+			g_config.bypass_antivm = value[0] == '1';
 		}
 		else if (!strcmp(key, "cpu-count")) {
 			unsigned int val = (unsigned int)strtoul(value, NULL, 10);

--- a/config.h
+++ b/config.h
@@ -96,7 +96,7 @@ struct _g_config {
 	int full_logs;
 
 	// should we attempt anti-anti-sandbox/VM tricks ?
-	int no_stealth;
+	int bypass_antivm;
 
 	// how many milliseconds since startup
 	unsigned int startup_time;

--- a/hook_file.c
+++ b/hook_file.c
@@ -508,7 +508,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtReadFile,
 		fname = calloc(32768, sizeof(wchar_t));
 		path_from_handle(FileHandle, fname, 32768);
 
-		if (!g_config.no_stealth && g_config.ntdll_unhook && InitialBufferLength)
+		if (!g_config.bypass_antivm && g_config.ntdll_unhook && InitialBufferLength)
 			prevent_module_unhooking(Buffer, fname);
 
 		if (read_count < 50)
@@ -915,7 +915,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtDeviceIoControlFile,
 		}
 	}
 
-	if (!g_config.no_stealth && NT_SUCCESS(ret) && OutputBuffer)
+	if (!g_config.bypass_antivm && NT_SUCCESS(ret) && OutputBuffer)
 		perform_device_fakery(OutputBuffer, (ULONG)length, IoControlCode);
 
 	if (origbuffer)
@@ -1376,7 +1376,7 @@ HOOKDEF(HANDLE, WINAPI, FindFirstFileExA,
 	HANDLE ret = Old_FindFirstFileExA(lpFileName, fInfoLevelId,
 		lpFindFileData, fSearchOp, lpSearchFilter, dwAdditionalFlags);
 
-	if (!g_config.no_stealth && ret != INVALID_HANDLE_VALUE && lpFileName &&
+	if (!g_config.bypass_antivm && ret != INVALID_HANDLE_VALUE && lpFileName &&
 		(!_strnicmp(lpFileName, g_config.analyzer, strlen(g_config.analyzer))
 			|| !_strnicmp(lpFileName, g_config.results, strlen(g_config.results))
 			|| !_strnicmp(lpFileName, g_config.pythonpath, strlen(g_config.pythonpath)))
@@ -1390,7 +1390,7 @@ HOOKDEF(HANDLE, WINAPI, FindFirstFileExA,
 		set_lasterrors(&lasterror);
 		ret = INVALID_HANDLE_VALUE;
 	}
-	else if (!g_config.no_stealth && ret != INVALID_HANDLE_VALUE &&
+	else if (!g_config.bypass_antivm && ret != INVALID_HANDLE_VALUE &&
 		(!stricmp(((PWIN32_FIND_DATAA)lpFindFileData)->cFileName, g_config.analyzer + 3) ||
 			!stricmp(((PWIN32_FIND_DATAA)lpFindFileData)->cFileName, g_config.results + 3) ||
 			!stricmp(((PWIN32_FIND_DATAA)lpFindFileData)->cFileName, g_config.pythonpath + 3)))
@@ -1409,7 +1409,7 @@ HOOKDEF(HANDLE, WINAPI, FindFirstFileExA,
 	}
 
 
-	if (!g_config.no_stealth && ret != INVALID_HANDLE_VALUE && (!stricmp(lpFileName, "c:\\windows") || !stricmp(lpFileName, "c:\\pagefile.sys")))
+	if (!g_config.bypass_antivm && ret != INVALID_HANDLE_VALUE && (!stricmp(lpFileName, "c:\\windows") || !stricmp(lpFileName, "c:\\pagefile.sys")))
 		perform_create_time_fakery(&((PWIN32_FIND_DATAA)lpFindFileData)->ftCreationTime);
 
 	if (g_config.sysvol_ctime.dwLowDateTime && ret != INVALID_HANDLE_VALUE && !stricmp(lpFileName, "c:\\System Volume Information"))
@@ -1438,7 +1438,7 @@ HOOKDEF(HANDLE, WINAPI, FindFirstFileExW,
 	HANDLE ret = Old_FindFirstFileExW(lpFileName, fInfoLevelId,
 		lpFindFileData, fSearchOp, lpSearchFilter, dwAdditionalFlags);
 
-	if (!g_config.no_stealth && ret != INVALID_HANDLE_VALUE && lpFileName &&
+	if (!g_config.bypass_antivm && ret != INVALID_HANDLE_VALUE && lpFileName &&
 		(!wcsnicmp(lpFileName, g_config.w_analyzer, wcslen(g_config.w_analyzer))
 			|| !wcsnicmp(lpFileName, g_config.w_results, wcslen(g_config.w_results))
 			|| !wcsnicmp(lpFileName, g_config.w_pythonpath, wcslen(g_config.w_pythonpath)))
@@ -1452,7 +1452,7 @@ HOOKDEF(HANDLE, WINAPI, FindFirstFileExW,
 		set_lasterrors(&lasterror);
 		ret = INVALID_HANDLE_VALUE;
 	}
-	else if (!g_config.no_stealth && ret != INVALID_HANDLE_VALUE &&
+	else if (!g_config.bypass_antivm && ret != INVALID_HANDLE_VALUE &&
 		(!wcsicmp(((PWIN32_FIND_DATAW)lpFindFileData)->cFileName, g_config.w_analyzer + 3) ||
 		 !wcsicmp(((PWIN32_FIND_DATAW)lpFindFileData)->cFileName, g_config.w_results + 3) ||
 		 !wcsicmp(((PWIN32_FIND_DATAW)lpFindFileData)->cFileName, g_config.w_pythonpath + 3)))
@@ -1470,7 +1470,7 @@ HOOKDEF(HANDLE, WINAPI, FindFirstFileExW,
 		}
 	}
 
-	if (!g_config.no_stealth && ret != INVALID_HANDLE_VALUE && (!wcsicmp(lpFileName, L"c:\\windows") || !wcsicmp(lpFileName, L"c:\\pagefile.sys")))
+	if (!g_config.bypass_antivm && ret != INVALID_HANDLE_VALUE && (!wcsicmp(lpFileName, L"c:\\windows") || !wcsicmp(lpFileName, L"c:\\pagefile.sys")))
 		perform_create_time_fakery(&((PWIN32_FIND_DATAW)lpFindFileData)->ftCreationTime);
 
 	if (g_config.sysvol_ctime.dwLowDateTime && ret != INVALID_HANDLE_VALUE && !wcsicmp(lpFileName, L"c:\\System Volume Information"))
@@ -1493,7 +1493,7 @@ HOOKDEF(BOOL, WINAPI, FindNextFileW,
 ) {
 	BOOL ret = Old_FindNextFileW(hFindFile, lpFindFileData);
 
-	while (!g_config.no_stealth && ret && (
+	while (!g_config.bypass_antivm && ret && (
 		!wcsicmp(lpFindFileData->cFileName, g_config.w_analyzer + 3) ||
 		!wcsicmp(lpFindFileData->cFileName, g_config.w_results + 3) ||
 		!wcsicmp(lpFindFileData->cFileName, g_config.w_pythonpath + 3))) {
@@ -1653,7 +1653,7 @@ HOOKDEF(BOOL, WINAPI, GetDiskFreeSpaceExA,
 ) {
 	BOOL ret = Old_GetDiskFreeSpaceExA(lpDirectoryName, lpFreeBytesAvailable, lpTotalNumberOfBytes, lpTotalNumberOfFreeBytes);
 	LOQ_bool("filesystem", "s", "DirectoryName", lpDirectoryName);
-	if (!g_config.no_stealth && ret && lpTotalNumberOfBytes) {
+	if (!g_config.bypass_antivm && ret && lpTotalNumberOfBytes) {
 		lpTotalNumberOfBytes->QuadPart = SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE;
 	}
 
@@ -1668,7 +1668,7 @@ HOOKDEF(BOOL, WINAPI, GetDiskFreeSpaceExW,
 ) {
 	BOOL ret = Old_GetDiskFreeSpaceExW(lpDirectoryName, lpFreeBytesAvailable, lpTotalNumberOfBytes, lpTotalNumberOfFreeBytes);
 	LOQ_bool("filesystem", "u", "DirectoryName", lpDirectoryName);
-	if (!g_config.no_stealth && ret && lpTotalNumberOfBytes) {
+	if (!g_config.bypass_antivm && ret && lpTotalNumberOfBytes) {
 		lpTotalNumberOfBytes->QuadPart = SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE;
 	}
 
@@ -1684,7 +1684,7 @@ HOOKDEF(BOOL, WINAPI, GetDiskFreeSpaceA,
 ) {
 	BOOL ret = Old_GetDiskFreeSpaceA(lpRootPathName, lpSectorsPerCluster, lpBytesPerSector, lpNumberOfFreeClusters, lpTotalNumberOfClusters);
 	LOQ_bool("filesystem", "s", "RootPathName", lpRootPathName);
-	if (!g_config.no_stealth) {
+	if (!g_config.bypass_antivm) {
 		__try {
 			if (lpTotalNumberOfClusters && lpSectorsPerCluster && lpBytesPerSector && *lpSectorsPerCluster && *lpBytesPerSector) {
 				*lpTotalNumberOfClusters = (DWORD)((SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE) / (*lpSectorsPerCluster * *lpBytesPerSector));
@@ -1707,7 +1707,7 @@ HOOKDEF(BOOL, WINAPI, GetDiskFreeSpaceW,
 ) {
 	BOOL ret = Old_GetDiskFreeSpaceW(lpRootPathName, lpSectorsPerCluster, lpBytesPerSector, lpNumberOfFreeClusters, lpTotalNumberOfClusters);
 	LOQ_bool("filesystem", "u", "RootPathName", lpRootPathName);
-	if (!g_config.no_stealth) {
+	if (!g_config.bypass_antivm) {
 		__try {
 			if (lpTotalNumberOfClusters && lpSectorsPerCluster && lpBytesPerSector && *lpSectorsPerCluster && *lpBytesPerSector) {
 				*lpTotalNumberOfClusters = (DWORD)((SPOOFED_DISK_SIZE - RECOVERY_PARTITION_SIZE) / (*lpSectorsPerCluster * *lpBytesPerSector));
@@ -1758,7 +1758,7 @@ HOOKDEF(BOOL, WINAPI, GetVolumeNameForVolumeMountPointW,
 	_In_ DWORD cchBufferLength
 ) {
 	BOOL ret = Old_GetVolumeNameForVolumeMountPointW(lpszVolumeMountPoint, lpszVolumeName, cchBufferLength);
-	if (!g_config.no_stealth && ret) {
+	if (!g_config.bypass_antivm && ret) {
 		replace_wstring_in_buf(lpszVolumeName, cchBufferLength, L"QEMU", L"DELL");
 		replace_wstring_in_buf(lpszVolumeName, cchBufferLength, L"VMware", L"DELL__");
 		replace_wstring_in_buf(lpszVolumeName, cchBufferLength, L"VMWar", L"WDRed");

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -321,7 +321,7 @@ HOOKDEF(BOOL, WINAPI, DeviceIoControl,
 		"InBuffer", nInBufferSize, lpInBuffer,
 		"OutBuffer", *lpBytesReturned, lpOutBuffer);
 
-	if (!g_config.no_stealth && ret && lpOutBuffer)
+	if (!g_config.bypass_antivm && ret && lpOutBuffer)
 		perform_device_fakery(lpOutBuffer, *lpBytesReturned, dwIoControlCode);
 
 	return ret;
@@ -572,7 +572,7 @@ HOOKDEF(int, WINAPI, GetSystemMetrics,
 ) {
 	int ret = Old_GetSystemMetrics(nIndex);
 
-	if (!g_config.no_stealth) {
+	if (!g_config.bypass_antivm) {
 		if (nIndex == SM_CXSCREEN || nIndex == SM_CXVIRTUALSCREEN)
 			ret = 1920;
 		else if (nIndex == SM_CYSCREEN || nIndex == SM_CYVIRTUALSCREEN)
@@ -691,7 +691,7 @@ HOOKDEF(BOOL, WINAPI, GetComputerNameExW,
 	if (nSize && *nSize)
 		bufsize = *nSize;
 	BOOL ret = Old_GetComputerNameExW(NameType, lpBuffer, nSize);
-	if (!g_config.no_stealth && ret && nSize && !*nSize && NameType >= 0 && NameType < ComputerNameMax && wcslen(ComputerNames[NameType]) < bufsize) {
+	if (!g_config.bypass_antivm && ret && nSize && !*nSize && NameType >= 0 && NameType < ComputerNameMax && wcslen(ComputerNames[NameType]) < bufsize) {
 		bufsize = (DWORD)wcslen(ComputerNames[NameType]);
 		wcsncpy(lpBuffer, ComputerNames[NameType], bufsize + 1);
 		*nSize = bufsize;
@@ -801,7 +801,7 @@ HOOKDEF(void, WINAPI, GetSystemInfo,
 
 	Old_GetSystemInfo(lpSystemInfo);
 
-	if (!g_config.no_stealth && lpSystemInfo->dwNumberOfProcessors < g_config.spoofed_cpu_count)
+	if (!g_config.bypass_antivm && lpSystemInfo->dwNumberOfProcessors < g_config.spoofed_cpu_count)
 		lpSystemInfo->dwNumberOfProcessors = g_config.spoofed_cpu_count;
 
 	LOQ_void("misc", "");
@@ -853,7 +853,7 @@ normal_call:
 		ret = Old_NtQuerySystemInformation(SystemInformationClass, SystemInformation, SystemInformationLength, ReturnLength);
 		LOQ_ntstatus("misc", "i", "SystemInformationClass", SystemInformationClass);
 
-		if (!g_config.no_stealth && SystemInformationClass == SystemHypervisorDetailInformation) {
+		if (!g_config.bypass_antivm && SystemInformationClass == SystemHypervisorDetailInformation) {
 			if (SystemInformation && SystemInformationLength > 0) {
 				memset(SystemInformation, 0, SystemInformationLength);
 			}
@@ -863,19 +863,19 @@ normal_call:
 			return 0xC0000003L; // STATUS_INVALID_INFO_CLASS
 		}
 
-		if (!g_config.no_stealth && SystemInformationClass == SystemBasicInformation && SystemInformationLength >= sizeof(SYSTEM_BASIC_INFORMATION) && NT_SUCCESS(ret)) {
+		if (!g_config.bypass_antivm && SystemInformationClass == SystemBasicInformation && SystemInformationLength >= sizeof(SYSTEM_BASIC_INFORMATION) && NT_SUCCESS(ret)) {
 			PSYSTEM_BASIC_INFORMATION p = (PSYSTEM_BASIC_INFORMATION)SystemInformation;
 			p->NumberOfProcessors = g_config.spoofed_cpu_count;
 		}
 
 		/* This is nearly arbitrary and simply designed to test whether the Upatre author(s) or others
 		are reading this code */
-		if (!g_config.no_stealth && SystemInformationClass == SystemProcessorPerformanceInformation &&
+		if (!g_config.bypass_antivm && SystemInformationClass == SystemProcessorPerformanceInformation &&
 			NT_SUCCESS(ret) && SystemInformationLength >= (sizeof(LARGE_INTEGER) * 3)) {
 			PSYSTEM_PROCESSOR_PERFORMANCE_INFORMATION perf_info = (PSYSTEM_PROCESSOR_PERFORMANCE_INFORMATION)SystemInformation;
 			perf_info->IdleTime.HighPart |= 2;
 		}
-		else if (!g_config.no_stealth && SystemInformationClass == SystemPerformanceInformation &&
+		else if (!g_config.bypass_antivm && SystemInformationClass == SystemPerformanceInformation &&
 			NT_SUCCESS(ret) && SystemInformationLength >= sizeof(LARGE_INTEGER)) {
 			PLARGE_INTEGER perf_info = (PLARGE_INTEGER)SystemInformation;
 			perf_info->HighPart |= 2;
@@ -1029,7 +1029,7 @@ HOOKDEF(BOOL, WINAPI, SetupDiGetDeviceRegistryPropertyA,
 
 	ret = Old_SetupDiGetDeviceRegistryPropertyA(DeviceInfoSet, DeviceInfoData, Property, PropertyRegDataType, PropertyBuffer, PropertyBufferSize, RequiredSize);
 
-	if (!g_config.no_stealth && ret && PropertyBuffer) {
+	if (!g_config.bypass_antivm && ret && PropertyBuffer) {
 		replace_ci_string_in_buf(PropertyBuffer, *RequiredSize, "VBOX", "DELL_");
 		replace_ci_string_in_buf(PropertyBuffer, *RequiredSize, "QEMU", "DELL");
 		replace_ci_string_in_buf(PropertyBuffer, *RequiredSize, "VMWARE", "DELL__");
@@ -1057,7 +1057,7 @@ HOOKDEF(BOOL, WINAPI, SetupDiGetDeviceRegistryPropertyW,
 
 	ret = Old_SetupDiGetDeviceRegistryPropertyW(DeviceInfoSet, DeviceInfoData, Property, PropertyRegDataType, PropertyBuffer, PropertyBufferSize, RequiredSize);
 
-	if (!g_config.no_stealth && ret && PropertyBuffer) {
+	if (!g_config.bypass_antivm && ret && PropertyBuffer) {
 		replace_ci_wstring_in_buf((PWCHAR)PropertyBuffer, *RequiredSize / sizeof(WCHAR), L"VBOX", L"DELL_");
 		replace_ci_wstring_in_buf((PWCHAR)PropertyBuffer, *RequiredSize / sizeof(WCHAR), L"QEMU", L"DELL");
 		replace_ci_wstring_in_buf((PWCHAR)PropertyBuffer, *RequiredSize / sizeof(WCHAR), L"VMWARE", L"DELL__");
@@ -1128,7 +1128,7 @@ HOOKDEF(DWORD, WINAPI, WNetGetProviderNameW,
 	LOQ_zero("misc", "iu", "NetType", dwNetType, "ProviderName", ret == NO_ERROR ? tmp : L"");
 
 	// WNNC_NET_RDR2SAMPLE, used for vbox detection
-	if (!g_config.no_stealth && ret && dwNetType == 0x250000) {
+	if (!g_config.bypass_antivm && ret && dwNetType == 0x250000) {
 		lasterror_t lasterrors;
 
 		ret = ERROR_NO_NETWORK;
@@ -1213,7 +1213,7 @@ HOOKDEF(void, WINAPI, GlobalMemoryStatus,
 ) {
 	BOOL ret = TRUE;
 	Old_GlobalMemoryStatus(lpBuffer);
-	if (!g_config.no_stealth && lpBuffer->dwTotalPhys < SPOOFED_RAM)
+	if (!g_config.bypass_antivm && lpBuffer->dwTotalPhys < SPOOFED_RAM)
 		lpBuffer->dwTotalPhys = (SIZE_T)SPOOFED_RAM;
 	LOQ_void("misc", "ii", "MemoryLoad", lpBuffer->dwMemoryLoad, "TotalPhysicalMB", lpBuffer->dwTotalPhys / (1024 * 1024));
 }
@@ -1222,7 +1222,7 @@ HOOKDEF(BOOL, WINAPI, GlobalMemoryStatusEx,
 	_Out_ LPMEMORYSTATUSEX lpBuffer
 ) {
 	BOOL ret = Old_GlobalMemoryStatusEx(lpBuffer);
-	if (ret && !g_config.no_stealth && lpBuffer->ullTotalPhys < SPOOFED_RAM)
+	if (ret && !g_config.bypass_antivm && lpBuffer->ullTotalPhys < SPOOFED_RAM)
 		lpBuffer->ullTotalPhys = SPOOFED_RAM;
 	LOQ_void("misc", "ii", "MemoryLoad", lpBuffer->dwMemoryLoad, "TotalPhysicalMB", lpBuffer->ullTotalPhys / (1024 * 1024));
 	return ret;
@@ -1232,7 +1232,7 @@ HOOKDEF(BOOL, WINAPI, GetPhysicallyInstalledSystemMemory,
 	_Out_ PULONGLONG TotalMemoryInKilobytes
 ) {
 	BOOL ret = Old_GetPhysicallyInstalledSystemMemory(TotalMemoryInKilobytes);
-	if (ret && !g_config.no_stealth && (*TotalMemoryInKilobytes * 1024) < SPOOFED_RAM)
+	if (ret && !g_config.bypass_antivm && (*TotalMemoryInKilobytes * 1024) < SPOOFED_RAM)
 		*TotalMemoryInKilobytes = SPOOFED_RAM / 1024;
 	LOQ_void("misc", "i", "TotalMemoryInKilobytes", *TotalMemoryInKilobytes);
 	return ret;
@@ -1826,7 +1826,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtQueryLicenseValue,
 ) {
 	WCHAR VMDetection[] = L"Kernel-VMDetection-Private";
 	NTSTATUS ret = Old_NtQueryLicenseValue(Name, Type, Buffer, Length, DataLength);
-	if (!g_config.no_stealth && NT_SUCCESS(ret) && Buffer && Name && Name->Buffer && Name->Length == sizeof(VMDetection) - sizeof(WCHAR) && !wcsncmp(Name->Buffer, VMDetection, Name->Length / sizeof(WCHAR)))
+	if (!g_config.bypass_antivm && NT_SUCCESS(ret) && Buffer && Name && Name->Buffer && Name->Length == sizeof(VMDetection) - sizeof(WCHAR) && !wcsncmp(Name->Buffer, VMDetection, Name->Length / sizeof(WCHAR)))
 		*(PBOOL)Buffer = FALSE;
 	LOQ_ntstatus("system", "oP", "Name", Name, "Type", Type);
 	return ret;
@@ -1875,7 +1875,7 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesA,
 	const char replacement[] = "NVIDIA GeForce RTX 3060";
 
 	BOOL ret = Old_EnumDisplayDevicesA(lpDevice, iDevNum, lpDisplayDevice, dwFlags);
-	if (!g_config.no_stealth && ret && lpDisplayDevice) {
+	if (!g_config.bypass_antivm && ret && lpDisplayDevice) {
 		for (int i = 0; i < keywords_size; i++) {
 			if (stristr(lpDisplayDevice->DeviceString, keywords[i]) != NULL) {
 				snprintf(lpDisplayDevice->DeviceString, strlen(replacement) + 1, replacement);
@@ -1905,7 +1905,7 @@ HOOKDEF(BOOL, WINAPI, EnumDisplayDevicesW,
 	const wchar_t replacement[] = L"NVIDIA GeForce RTX 3060";
 
 	BOOL ret = Old_EnumDisplayDevicesW(lpDevice, iDevNum, lpDisplayDevice, dwFlags);
-	if (!g_config.no_stealth && ret && lpDisplayDevice) {
+	if (!g_config.bypass_antivm && ret && lpDisplayDevice) {
 		for (int i = 0; i < keywords_size; i++) {
 			if (wcsistr(lpDisplayDevice->DeviceString, keywords[i]) != NULL) {
 				swprintf(lpDisplayDevice->DeviceString, wcslen(replacement) + 1, replacement);
@@ -1984,7 +1984,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtPowerInformation,
 	__in		ULONG				   OutputBufferLength
 ) {
 	NTSTATUS ret = Old_NtPowerInformation(InformationLevel, InputBuffer, InputBufferLength, OutputBuffer, OutputBufferLength);
-	if (!g_config.no_stealth && ret == 0 && OutputBuffer && InformationLevel == SystemPowerCapabilities && OutputBufferLength >= sizeof(SYSTEM_POWER_CAPABILITIES)) {
+	if (!g_config.bypass_antivm && ret == 0 && OutputBuffer && InformationLevel == SystemPowerCapabilities && OutputBufferLength >= sizeof(SYSTEM_POWER_CAPABILITIES)) {
 		// Most VM systems does not support either S0 or S3 sleep, which can be used to detect the presence of a VM.
 		// S0, S4 and S5 being enabled is typical for a normal Modern Standby machine. 
 		SYSTEM_POWER_CAPABILITIES* ptr = (SYSTEM_POWER_CAPABILITIES *)OutputBuffer;

--- a/hook_network.c
+++ b/hook_network.c
@@ -1004,7 +1004,7 @@ HOOKDEF(ULONG, WINAPI, NetGetJoinInformation,
 		LOQ_zero("network", "u", "Server", lpServer, "NetBIOSName");
 		return ret;
 	}
-	if (g_config.no_stealth)
+	if (g_config.bypass_antivm)
 		LOQ_zero("network", "uuI", "Server", lpServer, "NetBIOSName", *lpNameBuffer, "JoinStatus", BufferType);
 	else {
 		// Spoof domain membership to bypass sandbox detections

--- a/hook_reg.c
+++ b/hook_reg.c
@@ -36,7 +36,7 @@ HOOKDEF(LONG, WINAPI, RegOpenKeyExA,
 		phkResult);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && (ret == ERROR_SUCCESS || ret == ERROR_ACCESS_DENIED)) {
+	if (!g_config.bypass_antivm && (ret == ERROR_SUCCESS || ret == ERROR_ACCESS_DENIED)) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathA(hKey, lpSubKey, keybuf, allocsize);
@@ -68,7 +68,7 @@ HOOKDEF(LONG, WINAPI, RegOpenKeyExA,
 		}
 
 		// fake some values
-		if (lpSubKey && !g_config.no_stealth)
+		if (lpSubKey && !g_config.bypass_antivm)
 			perform_ascii_registry_fakery(keypath, (LPVOID)lpSubKey, (ULONG)strlen(lpSubKey));
 		free(keybuf);
 	}
@@ -90,7 +90,7 @@ HOOKDEF(LONG, WINAPI, RegOpenKeyExW,
 		phkResult);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && (ret == ERROR_SUCCESS || ret == ERROR_ACCESS_DENIED)) {
+	if (!g_config.bypass_antivm && (ret == ERROR_SUCCESS || ret == ERROR_ACCESS_DENIED)) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathW(hKey, lpSubKey, keybuf, allocsize);
@@ -122,7 +122,7 @@ HOOKDEF(LONG, WINAPI, RegOpenKeyExW,
 		}
 
 		// fake some values
-		if (lpSubKey && !g_config.no_stealth)
+		if (lpSubKey && !g_config.bypass_antivm)
 			perform_unicode_registry_fakery(keypath, lpSubKey, (ULONG)wcslen(lpSubKey));
 		free(keybuf);
 	}
@@ -150,7 +150,7 @@ HOOKDEF(LONG, WINAPI, RegCreateKeyExA,
 		lpdwDisposition);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && ret == ERROR_SUCCESS && *lpdwDisposition == REG_OPENED_EXISTING_KEY) {
+	if (!g_config.bypass_antivm && ret == ERROR_SUCCESS && *lpdwDisposition == REG_OPENED_EXISTING_KEY) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathA(hKey, lpSubKey, keybuf, allocsize);
@@ -198,7 +198,7 @@ HOOKDEF(LONG, WINAPI, RegCreateKeyExW,
 		lpdwDisposition);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && ret == ERROR_SUCCESS && *lpdwDisposition == REG_OPENED_EXISTING_KEY) {
+	if (!g_config.bypass_antivm && ret == ERROR_SUCCESS && *lpdwDisposition == REG_OPENED_EXISTING_KEY) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathW(hKey, lpSubKey, keybuf, allocsize);
@@ -279,7 +279,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyW,
 	LONG ret = Old_RegEnumKeyW(hKey, dwIndex, lpName, cchName);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && ret == ERROR_SUCCESS) {
+	if (!g_config.bypass_antivm && ret == ERROR_SUCCESS) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathW(hKey, NULL, keybuf, allocsize);
@@ -327,7 +327,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyExA,
 		lpClass, lpcClass, lpftLastWriteTime);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && ret == ERROR_SUCCESS) {
+	if (!g_config.bypass_antivm && ret == ERROR_SUCCESS) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathA(hKey, NULL, keybuf, allocsize);
@@ -354,7 +354,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyExA,
 		}
 
 		// fake some values
-		if (lpName && !g_config.no_stealth)
+		if (lpName && !g_config.bypass_antivm)
 			perform_ascii_registry_fakery(keypath, lpName, (ULONG)strlen(lpName));
 		free(keybuf);
 	}
@@ -378,7 +378,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyExW,
 		lpClass, lpcClass, lpftLastWriteTime);
 
 	// fake the absence of some keys
-	if (!g_config.no_stealth && ret == ERROR_SUCCESS) {
+	if (!g_config.bypass_antivm && ret == ERROR_SUCCESS) {
 		unsigned int allocsize = sizeof(KEY_NAME_INFORMATION) + MAX_KEY_BUFLEN;
 		PKEY_NAME_INFORMATION keybuf = malloc(allocsize);
 		wchar_t *keypath = get_full_key_pathW(hKey, NULL, keybuf, allocsize);
@@ -404,7 +404,7 @@ HOOKDEF(LONG, WINAPI, RegEnumKeyExW,
 		}
 
 		// fake some values
-		if (lpName && !g_config.no_stealth)
+		if (lpName && !g_config.bypass_antivm)
 			perform_unicode_registry_fakery(keypath, lpName, (ULONG)wcslen(lpName));
 		free(keybuf);
 	}
@@ -542,7 +542,7 @@ HOOKDEF(LONG, WINAPI, RegQueryValueExA,
 		wchar_t *keypath = get_full_keyvalue_pathA(hKey, lpValueName, keybuf, allocsize);
 
 		// fake some values
-		if (lpData && !g_config.no_stealth)
+		if (lpData && !g_config.bypass_antivm)
 			perform_ascii_registry_fakery(keypath, lpData, *lpcbData);
 
 		LOQ_zero("registry", "psru", "Handle", hKey, "ValueName", lpValueName,
@@ -581,7 +581,7 @@ HOOKDEF(LONG, WINAPI, RegQueryValueExW,
 		wchar_t *keypath = get_full_keyvalue_pathW(hKey, lpValueName, keybuf, allocsize);
 
 		// fake some values
-		if (lpData && !g_config.no_stealth)
+		if (lpData && !g_config.bypass_antivm)
 			perform_unicode_registry_fakery(keypath, lpData, *lpcbData);
 
 		LOQ_zero("registry", "puRu", "Handle", hKey, "ValueName", lpValueName,

--- a/hook_reg_native.c
+++ b/hook_reg_native.c
@@ -186,7 +186,7 @@ HOOKDEF(NTSTATUS, WINAPI, NtQueryValueKey,
 			"Type", Type, "Information", Type, DataLength, Data,
 			"FullName", keypath);
 
-		if (!g_config.no_stealth)
+		if (!g_config.bypass_antivm)
 			perform_unicode_registry_fakery(keypath, Data, DataLength);
 
 		free(keybuf);

--- a/hook_wmi.c
+++ b/hook_wmi.c
@@ -7,7 +7,7 @@ __declspec(thread) static int g_last_seen_disk_query = 0;
 __declspec(thread) static int g_last_seen_physicalmemory = 0;
 
 void SpoofWmiData(const wchar_t* szClassName, const wchar_t* wszName, VARIANT* pVal) {
-	if (g_config.no_stealth)
+	if (g_config.bypass_antivm)
 		return;
 
 	if (!szClassName || !wszName || !pVal)


### PR DESCRIPTION
Reversing double-negatives.  makes reasoning and configuration backwards. Renaming configuration flag to  across the monitor engine.