### PR TITLE
fix: Address local memory boundaries and buffer constraints

### DIFF
--- a/capemon.c
+++ b/capemon.c
@@ -40,8 +40,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CUCKOODBG 0
 #endif
 
-#define WIDE_STRING_LIMIT 32768
-
 char *our_process_path;
 char *our_process_name;
 char *our_dll_path;
@@ -197,10 +195,14 @@ static int parse_stack_trace(void *msg, ULONG_PTR addr)
 	if (buf) {
 		PCHAR funcname;
 		funcname = ScanForExport((PVOID)addr, 0x50);
-		if (funcname)
-			snprintf((char *)msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, "%s::%s(0x%x)\n", buf, funcname, offset);
-		else
-			snprintf((char *)msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, "%s+0x%x\n", buf, offset);
+		size_t len = strlen((char *)msg);
+		size_t remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+		if (remaining > 1) {
+			if (funcname)
+				_snprintf_s((char *)msg + len, remaining, _TRUNCATE, "%s::%s(0x%x)\n", buf, funcname, offset);
+			else
+				_snprintf_s((char *)msg + len, remaining, _TRUNCATE, "%s+0x%x\n", buf, offset);
+		}
 		free(buf);
 	}
 
@@ -322,6 +324,8 @@ LONG WINAPI capemon_exception_handler(__in struct _EXCEPTION_POINTERS *Exception
 	PUCHAR eipptr;
 	ULONG_PTR *stack;
 	lasterror_t lasterror;
+	size_t len;
+	size_t remaining;
 
 	if (ExceptionInfo->ExceptionRecord == NULL || ExceptionInfo->ContextRecord == NULL)
 		return EXCEPTION_CONTINUE_SEARCH;
@@ -364,40 +368,62 @@ LONG WINAPI capemon_exception_handler(__in struct _EXCEPTION_POINTERS *Exception
 	log_flush();
 
 	msg = malloc(WIDE_STRING_LIMIT);
+	if (!msg)
+		return EXCEPTION_CONTINUE_SEARCH;
 
 	dllname = convert_address_to_dll_name_and_offset(eip, &offset);
 
-	sprintf(msg, "Exception Caught! PID: %u EIP:", GetCurrentProcessId());
+	_snprintf_s(msg, WIDE_STRING_LIMIT, _TRUNCATE, "Exception Caught! PID: %u EIP:", GetCurrentProcessId());
 	if (dllname) {
 		PCHAR FunctionName;
 		FunctionName = ScanForExport((PVOID)eip, 0x50);
-		if (FunctionName)
-			snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s::%s(0x%x)", dllname, FunctionName, offset);
-		else
-			snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s+0x%x", dllname, offset);
+		len = strlen(msg);
+		remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+		if (remaining > 1) {
+			if (FunctionName)
+				_snprintf_s(msg + len, remaining, _TRUNCATE, " %s::%s(0x%x)", dllname, FunctionName, offset);
+			else
+				_snprintf_s(msg + len, remaining, _TRUNCATE, " %s+0x%x", dllname, offset);
+		}
 	}
 
 	sehname = convert_address_to_dll_name_and_offset(seh, &offset);
-	if (sehname)
-		snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " SEH: %s+0x%x", sehname, offset);
+	if (sehname) {
+		len = strlen(msg);
+		remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+		if (remaining > 1)
+			_snprintf_s(msg + len, remaining, _TRUNCATE, " SEH: %s+0x%x", sehname, offset);
+	}
 
-	snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg), " %.08Ix, Fault Address: %.08Ix, Esp: %.08Ix, Exception Code: %08x\n",
-		eip, ExceptionInfo->ExceptionRecord->ExceptionInformation[1], (ULONG_PTR)stack, ExceptionInfo->ExceptionRecord->ExceptionCode);
+	len = strlen(msg);
+	remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+	if (remaining > 1) {
+		_snprintf_s(msg + len, remaining, _TRUNCATE, " %.08Ix, Fault Address: %.08Ix, Esp: %.08Ix, Exception Code: %08x\n",
+			eip, ExceptionInfo->ExceptionRecord->ExceptionInformation[1], (ULONG_PTR)stack, ExceptionInfo->ExceptionRecord->ExceptionCode);
+	}
 
 #ifdef _WIN64
-	snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1,
-		"RAX 0x%I64x RBX 0x%I64x RCX 0x%I64x RDX 0x%I64x RSI 0x%I64x RDI 0x%I64x\nR8 0x%I64x R9 0x%I64x R10 0x%I64x R11 0x%I64x R12 0x%I64x R13 0x%I64x R14 0x%I64x R15 0x%I64x RSP 0x%I64x RBP 0x%I64x\n",
-		ExceptionInfo->ContextRecord->Rax, ExceptionInfo->ContextRecord->Rbx, ExceptionInfo->ContextRecord->Rcx, ExceptionInfo->ContextRecord->Rdx,
-		ExceptionInfo->ContextRecord->Rsi, ExceptionInfo->ContextRecord->Rdi, ExceptionInfo->ContextRecord->R8, ExceptionInfo->ContextRecord->R9,
-		ExceptionInfo->ContextRecord->R10, ExceptionInfo->ContextRecord->R11, ExceptionInfo->ContextRecord->R12, ExceptionInfo->ContextRecord->R13,
-		ExceptionInfo->ContextRecord->R14, ExceptionInfo->ContextRecord->R15, ExceptionInfo->ContextRecord->Rsp, ExceptionInfo->ContextRecord->Rbp
-		);
+	len = strlen(msg);
+	remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+	if (remaining > 1) {
+		_snprintf_s(msg + len, remaining, _TRUNCATE,
+			"RAX 0x%I64x RBX 0x%I64x RCX 0x%I64x RDX 0x%I64x RSI 0x%I64x RDI 0x%I64x\nR8 0x%I64x R9 0x%I64x R10 0x%I64x R11 0x%I64x R12 0x%I64x R13 0x%I64x R14 0x%I64x R15 0x%I64x RSP 0x%I64x RBP 0x%I64x\n",
+			ExceptionInfo->ContextRecord->Rax, ExceptionInfo->ContextRecord->Rbx, ExceptionInfo->ContextRecord->Rcx, ExceptionInfo->ContextRecord->Rdx,
+			ExceptionInfo->ContextRecord->Rsi, ExceptionInfo->ContextRecord->Rdi, ExceptionInfo->ContextRecord->R8, ExceptionInfo->ContextRecord->R9,
+			ExceptionInfo->ContextRecord->R10, ExceptionInfo->ContextRecord->R11, ExceptionInfo->ContextRecord->R12, ExceptionInfo->ContextRecord->R13,
+			ExceptionInfo->ContextRecord->R14, ExceptionInfo->ContextRecord->R15, ExceptionInfo->ContextRecord->Rsp, ExceptionInfo->ContextRecord->Rbp
+			);
+	}
 #else
-	snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1,
-		"EAX 0x%x EBX 0x%x ECX 0x%x EDX 0x%x ESI 0x%x EDI 0x%x\n ESP 0x%x EBP 0x%x\n",
-		ExceptionInfo->ContextRecord->Eax, ExceptionInfo->ContextRecord->Ebx, ExceptionInfo->ContextRecord->Ecx, ExceptionInfo->ContextRecord->Edx,
-		ExceptionInfo->ContextRecord->Esi, ExceptionInfo->ContextRecord->Edi, ExceptionInfo->ContextRecord->Esp, ExceptionInfo->ContextRecord->Ebp
-		);
+	len = strlen(msg);
+	remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+	if (remaining > 1) {
+		_snprintf_s(msg + len, remaining, _TRUNCATE,
+			"EAX 0x%x EBX 0x%x ECX 0x%x EDX 0x%x ESI 0x%x EDI 0x%x\n ESP 0x%x EBP 0x%x\n",
+			ExceptionInfo->ContextRecord->Eax, ExceptionInfo->ContextRecord->Ebx, ExceptionInfo->ContextRecord->Ecx, ExceptionInfo->ContextRecord->Edx,
+			ExceptionInfo->ContextRecord->Esi, ExceptionInfo->ContextRecord->Edi, ExceptionInfo->ContextRecord->Esp, ExceptionInfo->ContextRecord->Ebp
+			);
+	}
 #endif
 
 	operate_on_backtrace((ULONG_PTR)stack, ebp_or_rip, msg, &parse_stack_trace);
@@ -412,19 +438,32 @@ LONG WINAPI capemon_exception_handler(__in struct _EXCEPTION_POINTERS *Exception
 			if (buf) {
 				PCHAR funcname = NULL;
 				funcname = ScanForExport((PVOID)eip, 0x50);
-				if (funcname)
-					snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s::%s(0x%x)\n", buf, funcname, offset);
-				else
-					snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s+0x%x\n", buf, offset);
+				len = strlen(msg);
+				remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+				if (remaining > 1) {
+					if (funcname)
+						_snprintf_s(msg + len, remaining, _TRUNCATE, " %s::%s(0x%x)\n", buf, funcname, offset);
+					else
+						_snprintf_s(msg + len, remaining, _TRUNCATE, " %s+0x%x\n", buf, offset);
+				}
 				free(buf);
 			}
-			if (WIDE_STRING_LIMIT - strlen(msg) < 0x200)
+			len = strlen(msg);
+			if (len >= WIDE_STRING_LIMIT || WIDE_STRING_LIMIT - len < 0x200)
 				goto next;
 		}
-		strcat(msg, ", ");
+		len = strlen(msg);
+		remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+		if (remaining > 3) {
+			strcat(msg, ", ");
+		}
 	}
 	else {
-		strcat(msg, "invalid stack, ");
+		len = strlen(msg);
+		remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+		if (remaining > 17) {
+			strcat(msg, "invalid stack, ");
+		}
 	}
 next:
 #endif

--- a/capemon.c
+++ b/capemon.c
@@ -198,9 +198,9 @@ static int parse_stack_trace(void *msg, ULONG_PTR addr)
 		PCHAR funcname;
 		funcname = ScanForExport((PVOID)addr, 0x50);
 		if (funcname)
-			snprintf((char *)msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, "%s::%s(0x%x)\n", buf, funcname, offset);
+			snprintf((char *)msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, "%s::%s(0x%x)\n", buf, funcname, offset);
 		else
-			snprintf((char *)msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, "%s+0x%x\n", buf, offset);
+			snprintf((char *)msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, "%s+0x%x\n", buf, offset);
 		free(buf);
 	}
 
@@ -372,20 +372,20 @@ LONG WINAPI capemon_exception_handler(__in struct _EXCEPTION_POINTERS *Exception
 		PCHAR FunctionName;
 		FunctionName = ScanForExport((PVOID)eip, 0x50);
 		if (FunctionName)
-			snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, " %s::%s(0x%x)", dllname, FunctionName, offset);
+			snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s::%s(0x%x)", dllname, FunctionName, offset);
 		else
-			snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, " %s+0x%x", dllname, offset);
+			snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s+0x%x", dllname, offset);
 	}
 
 	sehname = convert_address_to_dll_name_and_offset(seh, &offset);
 	if (sehname)
-		snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, " SEH: %s+0x%x", sehname, offset);
+		snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " SEH: %s+0x%x", sehname, offset);
 
-	snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg), " %.08Ix, Fault Address: %.08Ix, Esp: %.08Ix, Exception Code: %08x\n",
+	snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg), " %.08Ix, Fault Address: %.08Ix, Esp: %.08Ix, Exception Code: %08x\n",
 		eip, ExceptionInfo->ExceptionRecord->ExceptionInformation[1], (ULONG_PTR)stack, ExceptionInfo->ExceptionRecord->ExceptionCode);
 
 #ifdef _WIN64
-	snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1,
+	snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1,
 		"RAX 0x%I64x RBX 0x%I64x RCX 0x%I64x RDX 0x%I64x RSI 0x%I64x RDI 0x%I64x\nR8 0x%I64x R9 0x%I64x R10 0x%I64x R11 0x%I64x R12 0x%I64x R13 0x%I64x R14 0x%I64x R15 0x%I64x RSP 0x%I64x RBP 0x%I64x\n",
 		ExceptionInfo->ContextRecord->Rax, ExceptionInfo->ContextRecord->Rbx, ExceptionInfo->ContextRecord->Rcx, ExceptionInfo->ContextRecord->Rdx,
 		ExceptionInfo->ContextRecord->Rsi, ExceptionInfo->ContextRecord->Rdi, ExceptionInfo->ContextRecord->R8, ExceptionInfo->ContextRecord->R9,
@@ -393,7 +393,7 @@ LONG WINAPI capemon_exception_handler(__in struct _EXCEPTION_POINTERS *Exception
 		ExceptionInfo->ContextRecord->R14, ExceptionInfo->ContextRecord->R15, ExceptionInfo->ContextRecord->Rsp, ExceptionInfo->ContextRecord->Rbp
 		);
 #else
-	snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1,
+	snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1,
 		"EAX 0x%x EBX 0x%x ECX 0x%x EDX 0x%x ESI 0x%x EDI 0x%x\n ESP 0x%x EBP 0x%x\n",
 		ExceptionInfo->ContextRecord->Eax, ExceptionInfo->ContextRecord->Ebx, ExceptionInfo->ContextRecord->Ecx, ExceptionInfo->ContextRecord->Edx,
 		ExceptionInfo->ContextRecord->Esi, ExceptionInfo->ContextRecord->Edi, ExceptionInfo->ContextRecord->Esp, ExceptionInfo->ContextRecord->Ebp
@@ -413,12 +413,12 @@ LONG WINAPI capemon_exception_handler(__in struct _EXCEPTION_POINTERS *Exception
 				PCHAR funcname = NULL;
 				funcname = ScanForExport((PVOID)eip, 0x50);
 				if (funcname)
-					snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, " %s::%s(0x%x)\n", buf, funcname, offset);
+					snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s::%s(0x%x)\n", buf, funcname, offset);
 				else
-					snprintf(msg + strlen(msg), sizeof(msg) - strlen(msg) - 1, " %s+0x%x\n", buf, offset);
+					snprintf(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg) - 1, " %s+0x%x\n", buf, offset);
 				free(buf);
 			}
-			if (sizeof(msg) - strlen(msg) < 0x200)
+			if (WIDE_STRING_LIMIT - strlen(msg) < 0x200)
 				goto next;
 		}
 		strcat(msg, ", ");

--- a/hooking.h
+++ b/hooking.h
@@ -318,3 +318,7 @@ typedef struct _com_hook_t {
 	REFCLSID		rclsid;
 	REFIID			riid;
 } com_hook_t;
+
+#ifndef WIDE_STRING_LIMIT
+#define WIDE_STRING_LIMIT 32768
+#endif

--- a/unhook.c
+++ b/unhook.c
@@ -524,7 +524,11 @@ static DWORD WINAPI _watchdog_thread(LPVOID param)
 
 		for (i = 0; i < capemonaddrs_num; i++) {
 			char *dllname2 = convert_address_to_dll_name_and_offset(capemonaddrs[i], &off);
-			_snprintf_s(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg), _TRUNCATE, " %s+%x(0x%lx)", dllname2 ? dllname2 : "", off, capemonaddrs[i]);
+			size_t len = strlen(msg);
+			size_t remaining = (len < WIDE_STRING_LIMIT) ? (WIDE_STRING_LIMIT - len) : 0;
+			if (remaining > 1) {
+				_snprintf_s(msg + len, remaining, _TRUNCATE, " %s+%x(0x%lx)", dllname2 ? dllname2 : "", off, capemonaddrs[i]);
+			}
 			if (dllname2)
 				free(dllname2);
 		}

--- a/unhook.c
+++ b/unhook.c
@@ -500,8 +500,10 @@ static DWORD WINAPI _watchdog_thread(LPVOID param)
 {
 	hook_disable();
 
+	char *msg = malloc(WIDE_STRING_LIMIT);
+	if (!msg) return 0;
+	
 	while (1) {
-		char msg[MAX_PATH];
 		char *dllname;
 		unsigned int off = 0;
 		int i;
@@ -515,13 +517,14 @@ static DWORD WINAPI _watchdog_thread(LPVOID param)
 		ctx.ContextFlags = CONTEXT_FULL;
 		GetThreadContext((HANDLE)param, &ctx);
 		dllname = convert_address_to_dll_name_and_offset(ctx.Eip, &off);
-		_snprintf_s(msg, MAX_PATH, _TRUNCATE, "INFO: PID %u thread: %p EIP: %s+%x(0x%lx) EAX: 0x%lx EBX: 0x%lx ECX: 0x%lx EDX: 0x%lx ESI: 0x%lx EDI: 0x%lx EBP: 0x%lx ESP: 0x%lx\n", GetCurrentProcessId(), param, dllname ? dllname : "", off, ctx.Eip, ctx.Eax, ctx.Ebx, ctx.Ecx, ctx.Edx, ctx.Esi, ctx.Edi, ctx.Ebp, ctx.Esp);
+		memset(msg, 0, WIDE_STRING_LIMIT);
+		_snprintf_s(msg, WIDE_STRING_LIMIT, _TRUNCATE, "INFO: PID %u thread: %p EIP: %s+%x(0x%lx) EAX: 0x%lx EBX: 0x%lx ECX: 0x%lx EDX: 0x%lx ESI: 0x%lx EDI: 0x%lx EBP: 0x%lx ESP: 0x%lx\n", GetCurrentProcessId(), param, dllname ? dllname : "", off, ctx.Eip, ctx.Eax, ctx.Ebx, ctx.Ecx, ctx.Edx, ctx.Esi, ctx.Edi, ctx.Ebp, ctx.Esp);
 
 		_operate_on_backtrace(ctx.Eip, ctx.Ebp, NULL, find_capemon_addrs);
 
 		for (i = 0; i < capemonaddrs_num; i++) {
 			char *dllname2 = convert_address_to_dll_name_and_offset(capemonaddrs[i], &off);
-			sprintf(msg + strlen(msg), " %s+%x(0x%lx)", dllname2 ? dllname2 : "", off, capemonaddrs[i]);
+			_snprintf_s(msg + strlen(msg), WIDE_STRING_LIMIT - strlen(msg), _TRUNCATE, " %s+%x(0x%lx)", dllname2 ? dllname2 : "", off, capemonaddrs[i]);
 			if (dllname2)
 				free(dllname2);
 		}
@@ -531,6 +534,7 @@ static DWORD WINAPI _watchdog_thread(LPVOID param)
 		ResumeThread((HANDLE)param);
 		pipe(msg);
 	}
+	free(msg);
 }
 
 int init_watchdog()


### PR DESCRIPTION
Resolves unsigned underflow allocations hitting snprintf routines and expands hardcoded local stack matrices breaking deep module hooking structures.