### PR TITLE
Fix infinite YaraScan loop when dump limit is reached

### DIFF
--- a/CAPE/CAPE.c
+++ b/CAPE/CAPE.c
@@ -1370,13 +1370,16 @@ void ProcessTrackedRegion(PTRACKEDREGION TrackedRegion)
 	}
 	else
 	{
+		if (g_config.dump_limit && DumpCount >= g_config.dump_limit)
+			TrackedRegion->PagesDumped = TRUE;
+
 		if (TraceIsRunning)
 			DebuggerOutput("ProcessTrackedRegion: Failed to dump region at 0x%p ", Address);
 		else
 			DebugOutput("ProcessTrackedRegion: Failed to dump region at 0x%p.\n", Address);
 	}
 
-	if (g_config.yarascan)
+	if (g_config.yarascan && (!TrackedRegion->PagesDumped || (g_config.dump_limit && DumpCount >= g_config.dump_limit)))
 		YaraScan(Address, Size);
 }
 


### PR DESCRIPTION
Fixes a bug in `ProcessTrackedRegion` where hitting the dump limit prevented `PagesDumped` from being set to `TRUE`. This bypassed entropy thresholds and caused an infinite loop of failed memory dumping and YARA scanning upon every intercepted call.

Tested locally, loop no longer triggers.