### PR TITLE
shared lock - part of #188

### DIFF
--- a/CAPE/CAPE.c
+++ b/CAPE/CAPE.c
@@ -3426,6 +3426,11 @@ void DumpInterestingRegions(MEMORY_BASIC_INFORMATION MemInfo)
 	char ModulePath[MAX_PATH];
 	BOOL MappedModule = GetMappedFileName(GetCurrentProcess(), MemInfo.AllocationBase, ModulePath, MAX_PATH);
 
+	// The two blocks below share CapeMetaData, DotNetCacheDumpCount and g_dotnet_jit
+	// with the compileMethod hook, which may still be running on CLR JIT worker
+	// threads while this teardown scan executes. Serialise against it.
+	EnterCriticalSection(&g_dotnet_jit_lock);
+
 	if (IsDotNetImage(MemInfo.BaseAddress) && !MappedModule && MemInfo.Protect == PAGE_READWRITE && MemInfo.Type == MEM_MAPPED && MemInfo.State == MEM_COMMIT)
 	{
 		DebugOutput("DumpInterestingRegions: Dumping .NET image at 0x%p.\n", MemInfo.BaseAddress);
@@ -3458,6 +3463,8 @@ void DumpInterestingRegions(MEMORY_BASIC_INFORMATION MemInfo)
 		else if (!g_config.jit_dumps)
 			DebugOutput("DumpInterestingRegions: Skipping .NET JIT native cache at 0x%p (jit-dumps=0)\n", MemInfo.BaseAddress);
 	}
+
+	LeaveCriticalSection(&g_dotnet_jit_lock);
 }
 
 //**************************************************************************************

--- a/CAPE/CAPE.h
+++ b/CAPE/CAPE.h
@@ -84,6 +84,11 @@ void DumpStrings(void);
 BOOL ProcessDumped;
 unsigned int DumpCount, DotNetCacheDumpCount;
 
+// Defined in hook_clr.c, initialised in DllMain. Serialises the .NET JIT dump
+// paths (this file's DumpInterestingRegions and the compileMethod hook) which
+// share DotNetCacheDumpCount, the CapeMetaData scratch struct and g_dotnet_jit.
+extern CRITICAL_SECTION g_dotnet_jit_lock;
+
 SYSTEM_INFO SystemInfo;
 PVOID CallingModule;
 


### PR DESCRIPTION
**`CAPE/CAPE.h`** — added `extern CRITICAL_SECTION g_dotnet_jit_lock;` (the lock defined in `hook_clr.c`, init'd in `DllMain`) so `CAPE.c` can share it.

**`CAPE/CAPE.c` `DumpInterestingRegions`** — wrapped both .NET blocks (the `IsDotNetImage` image dump and the `g_dotnet_jit` native-cache dump) in `EnterCriticalSection(&g_dotnet_jit_lock)` / `LeaveCriticalSection`. This serializes the teardown scan against the `compileMethod` hook (still running on JIT worker threads during teardown), so they no longer race on:
- `CapeMetaData` scratch fields → dumps can't get cross-written metadata
- `DotNetCacheDumpCount` check-then-increment → count stays exact vs. `jit_dumps`
- `g_dotnet_jit` reads vs. concurrent `lookup_add`

No early returns between Enter/Leave, so the lock can't leak. Lock ordering (`g_dotnet_jit_lock` → dump/log/heap) matches what `hook_clr.c` already established, so no AB‑BA deadlock. `DotNetCacheDumpCount` stays `unsigned int` — with both writers now under the same CS (grep confirms there are only two), atomics aren't needed.

Left as-is on purpose: the two other `lookup_get(&g_dotnet_jit, …)` reads at `CAPE.c:1094` / `1287` — pure reads of a prepend-only/never-deleted list, safe on x86/x64 without the lock.