### PR TITLE
Add .NET Profiling API fallback and anti-profiling mitigations

### DIFF
--- a/CAPE/AmsiDumper.cpp
+++ b/CAPE/AmsiDumper.cpp
@@ -48,8 +48,14 @@ extern "C" BOOL SetCapeMetaData(DWORD DumpType, DWORD TargetPid, HANDLE hTargetP
 
 HMODULE g_currentModule;
 
+extern "C" HRESULT STDMETHODCALLTYPE ProfilerDllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv);
+
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
 {
+    HRESULT hr = ProfilerDllGetClassObject(rclsid, riid, ppv);
+    if (SUCCEEDED(hr))
+        return hr;
+
     return Module<InProc>::GetModule().GetClassObject(rclsid, riid, ppv);
 }
 

--- a/alloc.h
+++ b/alloc.h
@@ -51,7 +51,7 @@ extern void *cm_calloc(size_t count, size_t size);
 #else
 static __inline void *cm_calloc(size_t count, size_t size)
 {
-	char *buf = cm_alloc(count * size);
+	char *buf = (char *)cm_alloc(count * size);
 	if (buf)
 		memset(buf, 0, count * size);
 	return buf;
@@ -60,7 +60,7 @@ static __inline void *cm_calloc(size_t count, size_t size)
 
 static __inline char *cm_strdup(const char *ptr)
 {
-	char *buf = cm_alloc(strlen(ptr) + 1);
+	char *buf = (char *)cm_alloc(strlen(ptr) + 1);
 	if (buf)
 		strncpy(buf, ptr, strlen(ptr) + 1);
 	return buf;

--- a/capemon.c
+++ b/capemon.c
@@ -631,6 +631,7 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD dwReason, LPVOID lpReserved)
 #if !CUCKOODBG
 		hide_module_from_peb(hModule);
 #endif
+		scrub_profiler_env_vars();
 
 		// obtain all protected pids
 		pipe2(pids, &length, "GETPIDS:");

--- a/capemon.vcxproj
+++ b/capemon.vcxproj
@@ -213,6 +213,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="alloc.c" />
+    <ClCompile Include="profiler.cpp" />
     <ClCompile Include="CAPE\AmsiDumper.cpp" />
     <ClCompile Include="CAPE\CAPE.c" />
     <ClCompile Include="CAPE\Debugger.c" />

--- a/capemon.vcxproj.filters
+++ b/capemon.vcxproj.filters
@@ -285,6 +285,9 @@
     <ClCompile Include="CAPE\InstrCallback.c">
       <Filter>Source Files\CAPE</Filter>
     </ClCompile>
+    <ClCompile Include="profiler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="CAPE\AmsiDumper.cpp">
       <Filter>Source Files\CAPE</Filter>
     </ClCompile>

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -1840,6 +1840,34 @@ HOOKDEF(LPSTR, WINAPI, GetCommandLineA,
 	return ret;
 }
 
+HOOKDEF(DWORD, WINAPI, GetEnvironmentVariableA,
+	LPCSTR lpName,
+	LPSTR  lpBuffer,
+	DWORD  nSize
+) {
+	if (lpName) {
+		if (!_stricmp(lpName, "COR_PROFILER") || !_stricmp(lpName, "COR_ENABLE_PROFILING") || !_stricmp(lpName, "CORECLR_PROFILER")) {
+			SetLastError(ERROR_ENVVAR_NOT_FOUND);
+			return 0;
+		}
+	}
+	return Old_GetEnvironmentVariableA(lpName, lpBuffer, nSize);
+}
+
+HOOKDEF(DWORD, WINAPI, GetEnvironmentVariableW,
+	LPCWSTR lpName,
+	LPWSTR  lpBuffer,
+	DWORD   nSize
+) {
+	if (lpName) {
+		if (!_wcsicmp(lpName, L"COR_PROFILER") || !_wcsicmp(lpName, L"COR_ENABLE_PROFILING") || !_wcsicmp(lpName, L"CORECLR_PROFILER")) {
+			SetLastError(ERROR_ENVVAR_NOT_FOUND);
+			return 0;
+		}
+	}
+	return Old_GetEnvironmentVariableW(lpName, lpBuffer, nSize);
+}
+
 HOOKDEF(LPWSTR, WINAPI, GetCommandLineW,
 	void
 ) {

--- a/hooks.c
+++ b/hooks.c
@@ -389,6 +389,8 @@ hook_t full_hooks[] = {
 	//HOOK(ntdll, RtlMoveMemory),
 	HOOK(kernel32, GetCommandLineA),
 	HOOK(kernel32, GetCommandLineW),
+	HOOK(kernel32, GetEnvironmentVariableA),
+	HOOK(kernel32, GetEnvironmentVariableW),
 	HOOK(shcore, CommandLineToArgvW),
 	HOOK(kernel32, OutputDebugStringA),
 	HOOK(kernel32, OutputDebugStringW),

--- a/hooks.h
+++ b/hooks.h
@@ -4123,6 +4123,18 @@ HOOKDEF(LPWSTR, WINAPI, GetCommandLineW,
 	void
 );
 
+HOOKDEF(DWORD, WINAPI, GetEnvironmentVariableA,
+	LPCSTR lpName,
+	LPSTR  lpBuffer,
+	DWORD  nSize
+);
+
+HOOKDEF(DWORD, WINAPI, GetEnvironmentVariableW,
+	LPCWSTR lpName,
+	LPWSTR  lpBuffer,
+	DWORD   nSize
+);
+
 HOOKDEF(LPWSTR, WINAPI, CommandLineToArgvW,
 	__in LPWSTR lpCmdLine,
 	__out int *pNumArgs

--- a/misc.c
+++ b/misc.c
@@ -1097,6 +1097,29 @@ void hide_module_from_peb(HMODULE module_handle)
 	}
 }
 
+void scrub_profiler_env_vars(void)
+{
+	PEB *peb = (PEB *)get_peb();
+	if (!peb || !peb->ProcessParameters || !peb->ProcessParameters->Environment)
+		return;
+
+	PWSTR env = (PWSTR)peb->ProcessParameters->Environment;
+
+	while (*env) {
+		if (_wcsnicmp(env, L"COR_PROFILER", 12) == 0 ||
+			_wcsnicmp(env, L"COR_ENABLE_PROFILING", 20) == 0 ||
+			_wcsnicmp(env, L"CORECLR_PROFILER", 16) == 0) {
+			
+			PWSTR ptr = env;
+			while (*ptr && *ptr != L'=') {
+				*ptr = L'Z';
+				ptr++;
+			}
+		}
+		env += wcslen(env) + 1;
+	}
+}
+
 PUNICODE_STRING get_basename_of_module(HMODULE module_handle)
 {
 	PLDR_DATA_TABLE_ENTRY mod;

--- a/misc.h
+++ b/misc.h
@@ -183,6 +183,7 @@ BOOL is_directory_objattr(const OBJECT_ATTRIBUTES *obj);
 BOOL file_exists(const OBJECT_ATTRIBUTES *obj);
 UNICODE_STRING* get_module_name(ULONG_PTR addr);
 void hide_module_from_peb(HMODULE module_handle);
+void scrub_profiler_env_vars(void);
 int path_is_system(const wchar_t *path_w);
 int path_is_program_files(const wchar_t *path_w);
 BOOLEAN parent_has_path(char* path);

--- a/profiler.cpp
+++ b/profiler.cpp
@@ -1,0 +1,271 @@
+#include "profiler.h"
+
+// Defined in hook_clr.c / capemon.c
+extern "C" {
+    #include "hooks.h"
+    extern unsigned int DotNetCacheDumpCount;
+    extern lookup_t g_dotnet_jit;
+    extern config_t g_config;
+}
+
+// Global profiler CLSID: {F39DABDF-BA6B-41E8-AB2A-16BE2E111005}
+const CLSID CLSID_CapemonProfiler = { 0xf39dabdf, 0xba6b, 0x41e8, { 0xab, 0x2a, 0x16, 0xbe, 0x2e, 0x11, 0x10, 0x05 } };
+
+CorProfiler::CorProfiler() : refCount(1), pCorProfilerInfo(nullptr)
+{
+}
+
+CorProfiler::~CorProfiler()
+{
+    if (pCorProfilerInfo)
+    {
+        pCorProfilerInfo->Release();
+        pCorProfilerInfo = nullptr;
+    }
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::QueryInterface(REFIID riid, void** ppvObject)
+{
+    if (!ppvObject)
+        return E_POINTER;
+
+    if (riid == IID_IUnknown || riid == IID_ICorProfilerCallback || riid == IID_ICorProfilerCallback2)
+    {
+        *ppvObject = this;
+        AddRef();
+        return S_OK;
+    }
+
+    *ppvObject = nullptr;
+    return E_NOINTERFACE;
+}
+
+ULONG STDMETHODCALLTYPE CorProfiler::AddRef()
+{
+    return InterlockedIncrement(&refCount);
+}
+
+ULONG STDMETHODCALLTYPE CorProfiler::Release()
+{
+    LONG count = InterlockedDecrement(&refCount);
+    if (count == 0)
+        delete this;
+    return count;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown *pICorProfilerInfoUnk)
+{
+    DebugOutput("CorProfiler: Initialize called\n");
+
+    HRESULT hr = pICorProfilerInfoUnk->QueryInterface(IID_ICorProfilerInfo, (void**)&pCorProfilerInfo);
+    if (FAILED(hr))
+    {
+        ErrorOutput("CorProfiler: Failed to query ICorProfilerInfo\n");
+        return hr;
+    }
+
+    // Monitor JIT compilation
+    DWORD eventMask = COR_PRF_MONITOR_JIT_COMPILATION;
+    hr = pCorProfilerInfo->SetEventMask(eventMask);
+    if (FAILED(hr))
+    {
+        ErrorOutput("CorProfiler: Failed to set event mask\n");
+        return hr;
+    }
+
+    DebugOutput("CorProfiler: Initialization successful\n");
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
+{
+    if (pCorProfilerInfo)
+    {
+        pCorProfilerInfo->Release();
+        pCorProfilerInfo = nullptr;
+    }
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock)
+{
+    if (!pCorProfilerInfo) return S_OK;
+
+    ModuleID moduleId;
+    mdToken methodToken;
+    HRESULT hr = pCorProfilerInfo->GetFunctionInfo(functionId, nullptr, &moduleId, &methodToken);
+    if (FAILED(hr)) return S_OK;
+
+    // Get metadata import interface
+    IMetaDataImport* pMetaDataImport = nullptr;
+    hr = pCorProfilerInfo->GetModuleMetaData(moduleId, ofRead, IID_IMetaDataImport, (IUnknown**)&pMetaDataImport);
+    if (FAILED(hr)) return S_OK;
+
+    WCHAR methodName[256];
+    ULONG nameLength;
+    mdTypeDef classToken;
+    hr = pMetaDataImport->GetMethodProps(methodToken, &classToken, methodName, ARRAYSIZE(methodName), &nameLength, nullptr, nullptr, nullptr, nullptr, nullptr);
+
+    WCHAR className[256] = {0};
+    if (SUCCEEDED(hr) && classToken != mdTypeDefNil)
+    {
+        pMetaDataImport->GetTypeDefProps(classToken, className, ARRAYSIZE(className), &nameLength, nullptr, nullptr);
+    }
+    pMetaDataImport->Release();
+
+    // Now get the IL code
+    LPCBYTE pMethodHeader;
+    ULONG cbMethodSize;
+    hr = pCorProfilerInfo->GetILFunctionBody(moduleId, methodToken, &pMethodHeader, &cbMethodSize);
+
+    if (SUCCEEDED(hr))
+    {
+        DebugOutput("CorProfiler JIT: %S.%S (Size: 0x%x)\n", className, methodName, cbMethodSize);
+        // We reuse the existing CAPE meta logging that hook_clr uses.
+        // We can't do Native break-on-jit easily from here because the Native code hasn't been generated yet (this is JITCompilationStarted).
+        // But we can dump the IL bytecode.
+        if (DotNetCacheDumpCount < g_config.jit_dumps) {
+            SetCapeMetaData(0, 0, NULL, (PVOID)pMethodHeader); // Use 0 for dump type, or define a new one if necessary.
+            DumpMemoryRaw((PVOID)pMethodHeader, (SIZE_T)cbMethodSize);
+            InterlockedIncrement(&DotNetCacheDumpCount);
+        }
+    }
+
+    return S_OK;
+}
+
+// --- All other ICorProfilerCallback methods (no-ops) ---
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainCreationStarted(AppDomainID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainCreationFinished(AppDomainID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownStarted(AppDomainID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownFinished(AppDomainID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadStarted(AssemblyID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyUnloadStarted(AssemblyID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyUnloadFinished(AssemblyID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadStarted(ModuleID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadFinished(ModuleID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ModuleAttachedToAssembly(ModuleID, AssemblyID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassLoadStarted(ClassID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassLoadFinished(ClassID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassUnloadStarted(ClassID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ClassUnloadFinished(ClassID, HRESULT) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::FunctionUnloadStarted(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationFinished(FunctionID, HRESULT, BOOL) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID, BOOL*) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchFinished(FunctionID, COR_PRF_JIT_CACHE) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::JITFunctionPitched(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID, FunctionID, BOOL*) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadCreated(ThreadID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadDestroyed(ThreadID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadAssignedToOSThread(ThreadID, DWORD) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientInvocationStarted() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientSendingMessage(GUID*, BOOL) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientReceivingReply(GUID*, BOOL) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingClientInvocationFinished() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerReceivingMessage(GUID*, BOOL) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerInvocationStarted() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerInvocationReturned() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RemotingServerSendingReply(GUID*, BOOL) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::UnmanagedToManagedTransition(FunctionID, COR_PRF_TRANSITION_REASON) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ManagedToUnmanagedTransition(FunctionID, COR_PRF_TRANSITION_REASON) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeSuspendFinished() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeSuspendAborted() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeResumeStarted() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeResumeFinished() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeThreadSuspended(ThreadID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RuntimeThreadResumed(ThreadID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::MovedReferences(ULONG, ObjectID[], ObjectID[], ULONG[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ObjectAllocated(ObjectID, ClassID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ObjectsAllocatedByClass(ULONG, ClassID[], ULONG[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ObjectReferences(ObjectID, ClassID, ULONG, ObjectID[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RootReferences(ULONG, ObjectID[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionThrown(ObjectID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFunctionEnter(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFunctionLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFilterEnter(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchFilterLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionSearchCatcherFound(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerEnter(UINT_PTR) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerLeave(UINT_PTR) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFunctionEnter(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFunctionLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFinallyEnter(FunctionID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFinallyLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatcherEnter(FunctionID, ObjectID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatcherLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::COMClassicVTableCreated(ClassID, REFGUID, void*, ULONG) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::COMClassicVTableDestroyed(ClassID, REFGUID, void*) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatchFunctionEnter(FunctionID, ObjectID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatchFunctionLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ThreadNameChanged(ThreadID, ULONG, WCHAR[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::GarbageCollectionStarted(int, BOOL[], COR_PRF_GC_REASON) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::SurvivingReferences(ULONG, ObjectID[], ULONG[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::GarbageCollectionFinished() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::FinalizeableObjectQueued(DWORD, ObjectID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::RootReferences2(ULONG, ObjectID[], COR_PRF_GC_ROOT_KIND[], COR_PRF_GC_ROOT_FLAGS[], UINT_PTR[]) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::HandleCreated(GCHandleID, ObjectID) { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::HandleDestroyed(GCHandleID) { return S_OK; }
+
+class CorProfilerClassFactory : public IClassFactory
+{
+private:
+    LONG refCount;
+public:
+    CorProfilerClassFactory() : refCount(1) {}
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) {
+        if (riid == IID_IUnknown || riid == IID_IClassFactory) {
+            *ppvObject = this;
+            AddRef();
+            return S_OK;
+        }
+        *ppvObject = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() {
+        return InterlockedIncrement(&refCount);
+    }
+
+    ULONG STDMETHODCALLTYPE Release() {
+        LONG count = InterlockedDecrement(&refCount);
+        if (count == 0) delete this;
+        return count;
+    }
+
+    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppvObject) {
+        if (pUnkOuter != nullptr) return CLASS_E_NOAGGREGATION;
+
+        CorProfiler* profiler = new CorProfiler();
+        if (!profiler) return E_OUTOFMEMORY;
+
+        HRESULT hr = profiler->QueryInterface(riid, ppvObject);
+        profiler->Release();
+        return hr;
+    }
+
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL fLock) {
+        return S_OK;
+    }
+};
+
+extern "C" HRESULT STDMETHODCALLTYPE ProfilerDllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+{
+    // AmsiDumper.cpp defines its own DllGetClassObject. We must either merge them or ensure only one exists.
+    // However, for the profiler we only care about CLSID_CapemonProfiler.
+    if (IsEqualCLSID(rclsid, CLSID_CapemonProfiler))
+    {
+        CorProfilerClassFactory* factory = new CorProfilerClassFactory();
+        if (!factory) return E_OUTOFMEMORY;
+        HRESULT hr = factory->QueryInterface(riid, ppv);
+        factory->Release();
+        return hr;
+    }
+
+    // Attempt to fallback to AmsiDumper if we merged them (not done here for brevity).
+    return CLASS_E_CLASSNOTAVAILABLE;
+}

--- a/profiler.cpp
+++ b/profiler.cpp
@@ -1,11 +1,16 @@
 #include "profiler.h"
 
+#pragma comment(lib, "corguids.lib")
+
+extern "C" int DumpMemoryRaw(PVOID Buffer, SIZE_T Size);
+extern "C" BOOL SetCapeMetaData(DWORD DumpType, DWORD TargetPid, HANDLE hTargetProcess, PVOID Address);
+
 // Defined in hook_clr.c / capemon.c
 extern "C" {
-    #include "hooks.h"
+    #include "hooking.h"
     extern unsigned int DotNetCacheDumpCount;
     extern lookup_t g_dotnet_jit;
-    extern config_t g_config;
+    extern struct _g_config g_config;
 }
 
 // Global profiler CLSID: {F39DABDF-BA6B-41E8-AB2A-16BE2E111005}
@@ -197,6 +202,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFinallyEnter(FunctionID) {
 HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFinallyLeave() { return S_OK; }
 HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatcherEnter(FunctionID, ObjectID) { return S_OK; }
 HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatcherLeave() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCLRCatcherFound() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCLRCatcherExecute() { return S_OK; }
 HRESULT STDMETHODCALLTYPE CorProfiler::COMClassicVTableCreated(ClassID, REFGUID, void*, ULONG) { return S_OK; }
 HRESULT STDMETHODCALLTYPE CorProfiler::COMClassicVTableDestroyed(ClassID, REFGUID, void*) { return S_OK; }
 HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionCatchFunctionEnter(FunctionID, ObjectID) { return S_OK; }

--- a/profiler.h
+++ b/profiler.h
@@ -1,0 +1,103 @@
+#include <windows.h>
+#include <corprof.h>
+#include <corhdr.h>
+
+extern "C" void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
+extern "C" void ErrorOutput(_In_ LPCTSTR lpOutputString, ...);
+
+class CorProfiler : public ICorProfilerCallback2
+{
+private:
+    LONG refCount;
+    ICorProfilerInfo* pCorProfilerInfo;
+
+public:
+    CorProfiler();
+    virtual ~CorProfiler();
+
+    // IUnknown methods
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
+    virtual ULONG STDMETHODCALLTYPE AddRef();
+    virtual ULONG STDMETHODCALLTYPE Release();
+
+    // ICorProfilerCallback methods (Partial implementation - only what we need)
+    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown *pICorProfilerInfoUnk);
+    virtual HRESULT STDMETHODCALLTYPE Shutdown();
+    virtual HRESULT STDMETHODCALLTYPE AppDomainCreationStarted(AppDomainID appDomainId);
+    virtual HRESULT STDMETHODCALLTYPE AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE AppDomainShutdownStarted(AppDomainID appDomainId);
+    virtual HRESULT STDMETHODCALLTYPE AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE AssemblyLoadStarted(AssemblyID assemblyId);
+    virtual HRESULT STDMETHODCALLTYPE AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE AssemblyUnloadStarted(AssemblyID assemblyId);
+    virtual HRESULT STDMETHODCALLTYPE AssemblyUnloadFinished(AssemblyID assemblyId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE ModuleLoadStarted(ModuleID moduleId);
+    virtual HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE ModuleUnloadStarted(ModuleID moduleId);
+    virtual HRESULT STDMETHODCALLTYPE ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE ModuleAttachedToAssembly(ModuleID moduleId, AssemblyID AssemblyId);
+    virtual HRESULT STDMETHODCALLTYPE ClassLoadStarted(ClassID classId);
+    virtual HRESULT STDMETHODCALLTYPE ClassLoadFinished(ClassID classId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE ClassUnloadStarted(ClassID classId);
+    virtual HRESULT STDMETHODCALLTYPE ClassUnloadFinished(ClassID classId, HRESULT hrStatus);
+    virtual HRESULT STDMETHODCALLTYPE FunctionUnloadStarted(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId, BOOL fIsSafeToBlock);
+    virtual HRESULT STDMETHODCALLTYPE JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock);
+    virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchStarted(FunctionID functionId, BOOL *pbUseCachedFunction);
+    virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchFinished(FunctionID functionId, COR_PRF_JIT_CACHE result);
+    virtual HRESULT STDMETHODCALLTYPE JITFunctionPitched(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE JITInlining(FunctionID callerId, FunctionID calleeId, BOOL *pfShouldInline);
+    virtual HRESULT STDMETHODCALLTYPE ThreadCreated(ThreadID threadId);
+    virtual HRESULT STDMETHODCALLTYPE ThreadDestroyed(ThreadID threadId);
+    virtual HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread(ThreadID managedThreadId, DWORD osThreadId);
+    virtual HRESULT STDMETHODCALLTYPE RemotingClientInvocationStarted();
+    virtual HRESULT STDMETHODCALLTYPE RemotingClientSendingMessage(GUID *pCookie, BOOL fIsAsync);
+    virtual HRESULT STDMETHODCALLTYPE RemotingClientReceivingReply(GUID *pCookie, BOOL fIsAsync);
+    virtual HRESULT STDMETHODCALLTYPE RemotingClientInvocationFinished();
+    virtual HRESULT STDMETHODCALLTYPE RemotingServerReceivingMessage(GUID *pCookie, BOOL fIsAsync);
+    virtual HRESULT STDMETHODCALLTYPE RemotingServerInvocationStarted();
+    virtual HRESULT STDMETHODCALLTYPE RemotingServerInvocationReturned();
+    virtual HRESULT STDMETHODCALLTYPE RemotingServerSendingReply(GUID *pCookie, BOOL fIsAsync);
+    virtual HRESULT STDMETHODCALLTYPE UnmanagedToManagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason);
+    virtual HRESULT STDMETHODCALLTYPE ManagedToUnmanagedTransition(FunctionID functionId, COR_PRF_TRANSITION_REASON reason);
+    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason);
+    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendFinished();
+    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendAborted();
+    virtual HRESULT STDMETHODCALLTYPE RuntimeResumeStarted();
+    virtual HRESULT STDMETHODCALLTYPE RuntimeResumeFinished();
+    virtual HRESULT STDMETHODCALLTYPE RuntimeThreadSuspended(ThreadID threadId);
+    virtual HRESULT STDMETHODCALLTYPE RuntimeThreadResumed(ThreadID threadId);
+    virtual HRESULT STDMETHODCALLTYPE MovedReferences(ULONG cMovedObjectIDRanges, ObjectID oldObjectIDRangeStart[], ObjectID newObjectIDRangeStart[], ULONG cObjectIDRangeLength[]);
+    virtual HRESULT STDMETHODCALLTYPE ObjectAllocated(ObjectID objectId, ClassID classId);
+    virtual HRESULT STDMETHODCALLTYPE ObjectsAllocatedByClass(ULONG cClassCount, ClassID classIds[], ULONG cObjects[]);
+    virtual HRESULT STDMETHODCALLTYPE ObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[]);
+    virtual HRESULT STDMETHODCALLTYPE RootReferences(ULONG cRootRefs, ObjectID rootRefIds[]);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionThrown(ObjectID thrownObjectId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionEnter(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionLeave();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterEnter(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterLeave();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchCatcherFound(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionOSHandlerEnter(UINT_PTR __unused);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionOSHandlerLeave(UINT_PTR __unused);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionEnter(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionLeave();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyEnter(FunctionID functionId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyLeave();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherLeave();
+    virtual HRESULT STDMETHODCALLTYPE COMClassicVTableCreated(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable, ULONG cSlots);
+    virtual HRESULT STDMETHODCALLTYPE COMClassicVTableDestroyed(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatchFunctionEnter(FunctionID functionId, ObjectID objectId);
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatchFunctionLeave();
+
+    // ICorProfilerCallback2 methods
+    virtual HRESULT STDMETHODCALLTYPE ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[]);
+    virtual HRESULT STDMETHODCALLTYPE GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason);
+    virtual HRESULT STDMETHODCALLTYPE SurvivingReferences(ULONG cSurvivingObjectIDRanges, ObjectID objectIDRangeStart[], ULONG cObjectIDRangeLength[]);
+    virtual HRESULT STDMETHODCALLTYPE GarbageCollectionFinished();
+    virtual HRESULT STDMETHODCALLTYPE FinalizeableObjectQueued(DWORD finalizerFlags, ObjectID objectID);
+    virtual HRESULT STDMETHODCALLTYPE RootReferences2(ULONG cRootRefs, ObjectID rootRefIds[], COR_PRF_GC_ROOT_KIND rootKinds[], COR_PRF_GC_ROOT_FLAGS rootFlags[], UINT_PTR rootIds[]);
+    virtual HRESULT STDMETHODCALLTYPE HandleCreated(GCHandleID handleId, ObjectID initialObjectId);
+    virtual HRESULT STDMETHODCALLTYPE HandleDestroyed(GCHandleID handleId);
+};

--- a/profiler.h
+++ b/profiler.h
@@ -1,6 +1,11 @@
+#ifdef _MSC_VER
+#include <WinSock2.h>
+#endif
 #include <windows.h>
-#include <corprof.h>
+#include <unknwn.h>
+#include <cor.h>
 #include <corhdr.h>
+#include <corprof.h>
 
 extern "C" void DebugOutput(_In_ LPCTSTR lpOutputString, ...);
 extern "C" void ErrorOutput(_In_ LPCTSTR lpOutputString, ...);
@@ -86,6 +91,8 @@ public:
     virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyLeave();
     virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId);
     virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherLeave();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherFound();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherExecute();
     virtual HRESULT STDMETHODCALLTYPE COMClassicVTableCreated(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable, ULONG cSlots);
     virtual HRESULT STDMETHODCALLTYPE COMClassicVTableDestroyed(ClassID wrappedClassId, REFGUID implementedIID, void *pVTable);
     virtual HRESULT STDMETHODCALLTYPE ExceptionCatchFunctionEnter(FunctionID functionId, ObjectID objectId);


### PR DESCRIPTION
Implements the .NET Profiling API as a lab/debug fallback mode.

- Adds `profiler.h` and `profiler.cpp` implementing `ICorProfilerCallback2` for JIT monitoring and IL bytecode dumping.
- Merges the `DllGetClassObject` COM export alongside `AmsiDumper`.
- Proactively zeroes out `COR_PROFILER`, `COR_ENABLE_PROFILING`, and `CORECLR_PROFILER` from `PEB->ProcessParameters->Environment`.
- Adds inline hooks for `GetEnvironmentVariableA/W` to return `ERROR_ENVVAR_NOT_FOUND` to mitigate higher-level C# anti-profiling checks (like ConfuserEx).