### PR TITLE
fix(pipe): bind loaded notices to process identity

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -23,10 +23,10 @@ jobs:
             platform: x64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
       with: 
        msbuild-architecture: ${{ matrix.arch }}
 
@@ -38,12 +38,12 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{ matrix.platform }} ${{env.SOLUTION_FILE_PATH}}
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: capemon_release_${{ matrix.arch }}
         path: D:\a\capemon\capemon\Release\capemon.dll
         if-no-files-found: ignore
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: capemon_release_${{ matrix.arch }}
         path: D:\a\capemon\capemon\x64\Release\capemon_x64.dll

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -25,6 +25,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Visual Studio 2017 toolset
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+        $installPath = & $vswhere -latest -products * -property installationPath
+        $arguments = "modify --installPath `"$installPath`" --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --quiet --norestart"
+        $process = Start-Process -FilePath $installer -ArgumentList $arguments -Wait -PassThru
+        if ($process.ExitCode -ne 0) {
+          throw "Visual Studio Installer exited with code $($process.ExitCode)"
+        }
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
       with: 

--- a/capemon.c
+++ b/capemon.c
@@ -477,8 +477,18 @@ next:
 
 void notify_successful_load(void)
 {
-	// notify analyzer.py that we've loaded
-	pipe("LOADED:%d", GetCurrentProcessId());
+	// Bind the acknowledgement to this process instance so the analyzer can
+	// reject a delayed message after Windows reuses the numeric PID.
+	FILETIME CreationTime, ExitTime, KernelTime, UserTime;
+	ULARGE_INTEGER CreationIdentity;
+	if (GetProcessTimes(GetCurrentProcess(), &CreationTime, &ExitTime, &KernelTime, &UserTime)) {
+		CreationIdentity.LowPart = CreationTime.dwLowDateTime;
+		CreationIdentity.HighPart = CreationTime.dwHighDateTime;
+		pipe("LOADED:%d,i:%llu", GetCurrentProcessId(), (unsigned long long)CreationIdentity.QuadPart);
+	}
+	else {
+		pipe("LOADED:%d", GetCurrentProcessId());
+	}
 }
 
 void get_our_process_path(void)

--- a/capemon.c
+++ b/capemon.c
@@ -482,9 +482,19 @@ void notify_successful_load(void)
 	FILETIME CreationTime, ExitTime, KernelTime, UserTime;
 	ULARGE_INTEGER CreationIdentity;
 	if (GetProcessTimes(GetCurrentProcess(), &CreationTime, &ExitTime, &KernelTime, &UserTime)) {
+		char Identity[21];
+		int Length;
 		CreationIdentity.LowPart = CreationTime.dwLowDateTime;
 		CreationIdentity.HighPart = CreationTime.dwHighDateTime;
-		pipe("LOADED:%d,i:%llu", GetCurrentProcessId(), (unsigned long long)CreationIdentity.QuadPart);
+		Length = snprintf(Identity, sizeof(Identity), "%llu", (unsigned long long)CreationIdentity.QuadPart);
+		if (Length > 0 && (size_t)Length < sizeof(Identity)) {
+			// pipe() has a deliberately small custom formatter; %z passes a
+			// preformatted NUL-terminated ASCII string through unchanged.
+			pipe("LOADED:%d,i:%z", GetCurrentProcessId(), Identity);
+		}
+		else {
+			pipe("LOADED:%d", GetCurrentProcessId());
+		}
 	}
 	else {
 		pipe("LOADED:%d", GetCurrentProcessId());

--- a/capemon.c
+++ b/capemon.c
@@ -477,10 +477,18 @@ next:
 
 void notify_successful_load(void)
 {
-	// Bind the acknowledgement to this process instance so the analyzer can
-	// reject a delayed message after Windows reuses the numeric PID.
 	FILETIME CreationTime, ExitTime, KernelTime, UserTime;
 	ULARGE_INTEGER CreationIdentity;
+
+	// Old analyzers only accept LOADED:<pid>. Preserve that protocol unless
+	// the monitor config explicitly advertises tagged-identity support.
+	if (!g_config.loaded_process_identity) {
+		pipe("LOADED:%d", GetCurrentProcessId());
+		return;
+	}
+
+	// Bind the acknowledgement to this process instance so the analyzer can
+	// reject a delayed message after Windows reuses the numeric PID.
 	if (GetProcessTimes(GetCurrentProcess(), &CreationTime, &ExitTime, &KernelTime, &UserTime)) {
 		char Identity[21];
 		int Length;

--- a/config.c
+++ b/config.c
@@ -123,6 +123,9 @@ void parse_config_line(char* line)
 		else if (!strcmp(key, "first-process")) {
 			g_config.first_process = value[0] == '1';
 		}
+		else if (!strcmp(key, "loaded-process-identity")) {
+			g_config.loaded_process_identity = value[0] == '1';
+		}
 		else if (!strcmp(key, "startup-time")) {
 			g_config.startup_time = atoi(value);
 		}

--- a/config.h
+++ b/config.h
@@ -92,6 +92,9 @@ struct _g_config {
 	// is this the first process or not?
 	int first_process;
 
+	// analyzer supports LOADED messages tagged with a process creation identity
+	int loaded_process_identity;
+
 	// do we want to ignore "file of interest" and other forms of log reduction?
 	int full_logs;
 


### PR DESCRIPTION
## Summary

- include the current process creation FILETIME in successful monitor-load acknowledgements
- preformat the 64-bit identity before passing it through CAPEMON's intentionally limited `pipe()` formatter
- preserve the legacy `LOADED:<pid>` fallback if the process identity cannot be obtained or formatted
- emit identity-tagged acknowledgements only when the analyzer advertises support in the monitor config
- update the Windows Actions runner and install the required Visual Studio v141 toolset so both native architectures build in CI

## Why

The analyzer needs to distinguish a delayed monitor acknowledgement from a new process that reused the same numeric PID. The creation FILETIME provides that instance identity.

## Compatibility

The analyzer and monitor negotiate the tagged protocol. Either repository PR may be merged or deployed first: an older analyzer does not write the capability, so this monitor sends legacy `LOADED:<pid>`; the updated analyzer also accepts legacy acknowledgements from an older monitor. Identity validation activates when both sides are updated.

Companion CAPEv2 PR: https://github.com/kevoreilly/CAPEv2/pull/3211

## Verification

- Windows MSBuild CI passed for Win32/x86 and x64 on commit `c447d8b` (run `34073283202`)
- adversarial Marla review of the final native delta — AGY, Codex, and Qwen returned no findings
- live Windows 11 regression using the original missed sample, CAPE task 18647:
  - WmiPrvSE and all three PowerShell children emitted valid load acknowledgements
  - zero malformed-format, pipe-handler, stale-identity, or injection-failure errors
- mixed-version Windows 11 tests on toolz4:
  - task 18734: pre-capability analyzer + this CAPEMON — three PowerShell children loaded, zero protocol errors
  - task 18735: updated analyzer + legacy CAPEMON — three PowerShell children loaded, zero protocol errors
  - task 18736: updated analyzer + this CAPEMON — three PowerShell children loaded, zero protocol errors
